### PR TITLE
feature: signIn-oauth

### DIFF
--- a/src/main/java/homes/banzzokee/domain/oauth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/oauth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package homes.banzzokee.domain.oauth.controller;
+
+import homes.banzzokee.domain.oauth.dto.TokenDto;
+import homes.banzzokee.domain.oauth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @GetMapping("/google/callback")
+  public ResponseEntity<TokenDto> getGoogleToken(@RequestParam("code") String code) {
+    return ResponseEntity.ok(authService.getGoogleToken(code));
+  }
+
+}

--- a/src/main/java/homes/banzzokee/domain/oauth/dto/TokenDto.java
+++ b/src/main/java/homes/banzzokee/domain/oauth/dto/TokenDto.java
@@ -1,0 +1,19 @@
+package homes.banzzokee.domain.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TokenDto {
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+}

--- a/src/main/java/homes/banzzokee/domain/oauth/exception/TokenRequiredException.java
+++ b/src/main/java/homes/banzzokee/domain/oauth/exception/TokenRequiredException.java
@@ -1,0 +1,11 @@
+package homes.banzzokee.domain.oauth.exception;
+
+import homes.banzzokee.global.error.ErrorCode;
+import homes.banzzokee.global.error.exception.CustomException;
+
+public class TokenRequiredException extends CustomException {
+
+  public TokenRequiredException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/oauth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/oauth/service/AuthService.java
@@ -1,0 +1,48 @@
+package homes.banzzokee.domain.oauth.service;
+
+import homes.banzzokee.domain.oauth.dto.TokenDto;
+import homes.banzzokee.domain.oauth.exception.TokenRequiredException;
+import homes.banzzokee.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  @Value("${oauth2.client.registration.google.client_id}")
+  private String clientId;
+
+  @Value("${oauth2.client.registration.google.client_secret}")
+  private String clientSecret;
+
+  @Value("${oauth2.client.registration.google.redirect_uri}")
+  private String redirectUri;
+
+  public TokenDto getGoogleToken(String code) {
+    String googleTokenUrl = "https://oauth2.googleapis.com/token";
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("code", code);
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", redirectUri);
+    params.add("grant_type", "authorization_code");
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+    ResponseEntity<TokenDto> tokenResponse = restTemplate.postForEntity(googleTokenUrl, request, TokenDto.class);
+    if (tokenResponse.getStatusCode().value() != 200) {
+      throw new TokenRequiredException(ErrorCode.TOKEN_REQUIRED);
+    }
+    return tokenResponse.getBody();
+  }
+}

--- a/src/main/java/homes/banzzokee/global/error/ErrorCode.java
+++ b/src/main/java/homes/banzzokee/global/error/ErrorCode.java
@@ -1,10 +1,10 @@
 package homes.banzzokee.global.error;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -12,8 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   FAILED(BAD_REQUEST, "실패했습니다."),
-
-  ;
+  TOKEN_REQUIRED(UNAUTHORIZED, "토큰이 필요합니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,8 @@
+oauth2:
+  client:
+    registration:
+      google:
+        client_id: ${GOOGLE_CLIENT_ID}
+        client_secret: ${GOOGLE_CLIENT_SECRET}
+        redirect_uri: http://localhost:8080/api/auth/google/callback
+        scope: email, profile

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,6 @@ server:
 
 spring:
   profiles:
-    include: jpa
+    include: jpa, oauth
+
+

--- a/src/test/java/homes/banzzokee/domain/oauth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/oauth/controller/AuthControllerTest.java
@@ -1,0 +1,69 @@
+package homes.banzzokee.domain.oauth.controller;
+
+import homes.banzzokee.domain.oauth.dto.TokenDto;
+import homes.banzzokee.domain.oauth.exception.TokenRequiredException;
+import homes.banzzokee.domain.oauth.service.AuthService;
+import homes.banzzokee.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = AuthController.class)
+class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AuthService authService;
+
+  @Test
+  @DisplayName("구글 로그인 토큰 발급 성공")
+  @WithMockUser(username = "banzzokee", roles = "GOOGLE")
+  void successGetGoogleToken() throws Exception {
+    //given
+    String code = "test_code";
+    TokenDto expectedTokenDto = TokenDto.builder()
+        .accessToken("testAccessToken")
+        .refreshToken("testRefreshToken")
+        .build();
+    given(authService.getGoogleToken(any())).willReturn(expectedTokenDto);
+
+    //when
+    ResultActions actions = mockMvc.perform(get("/api/auth/google/callback")
+        .param("code", code));
+
+    //then
+    actions.andExpect(status().isOk());
+    actions.andExpect(jsonPath("$.access_token").value("testAccessToken"));
+    actions.andExpect(jsonPath("$.refresh_token").value("testRefreshToken"));
+  }
+
+  @Test
+  @DisplayName("구글 로그인 토큰 발급 실패")
+  @WithMockUser(username = "banzzokee", roles = "GOOGLE")
+  void failGetGoogleToken() throws Exception {
+    //given
+    String code = "test_code";
+    given(authService.getGoogleToken(any()))
+        .willThrow(new TokenRequiredException(ErrorCode.TOKEN_REQUIRED));
+
+    //when
+    ResultActions actions = mockMvc.perform(get("/api/auth/google/callback")
+        .param("code", code));
+
+    //then
+    actions.andExpect(status().is4xxClientError());
+  }
+}


### PR DESCRIPTION
## Changes
- Google 로그인 페이지에서 로그인 시 accessToken 및 refreshToken 발급 API 추가했습니다.

## Background
- Google 로그인 시 OAuth2 를 활용한 API 기능이 필요로 하다.

## Discuss
- requestParam 에 들어갈 code 값과 application-oauth.yml 환경 변수 설정 해놓은 Key 값  API 명세서 `/api/auth/google/callback` 파일안에 작성해 놓았습니다.

## Issues
해결한 이슈: #16 

## Execute
- mock을 활용한 컨트롤러 단위테스트 진행하였습니다.
  - 토큰 발급 성공 테스트
  - 토큰 발급 실패 테스트

## Reference
