### PR TITLE
feature: send verify auth

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/dto/EmailDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/EmailDto.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EmailDto {
+  /**
+   * email 인증할 이메일
+   */
 
   @NotBlank(message = "email 은 필수 입력 항목입니다.")
   @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "올바른 이메일 형식을 입력해주세요.")

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -21,14 +21,15 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class AuthService {
 
-  private static final String EMAIL_SUBJECT = "인증 코드" ;
-  private static final String EMAIL_TEXT = "인증 코드는 %s 입니다." ;
+  private static final String EMAIL_SUBJECT = "인증 코드";
+  private static final String EMAIL_TEXT = "인증 코드는 %s 입니다.";
   private static final int VERIFICATION_CODE_EXPIRATION_TIME = 3;
   private static final int VERIFICATION_CODE_MIN_VALUE = 100000;
   private static final int VERIFICATION_CODE_MAX_VALUE = 900000;
 
   private final JavaMailSender mailSender;
   private final RedisService redisService;
+
   private final UserRepository userRepository;
 
   public void signup(SignupDto signupDto) {

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -87,15 +87,16 @@ class AuthControllerTest {
     String requestBody = objectMapper.writeValueAsString(emailVerifyDto);
 
     // when & then
-    mockMvc.perform(post("/api/auth/verify")
+    mockMvc.perform(post("/api/auth/send-verify")
             .contentType(MediaType.APPLICATION_JSON)
             .content(requestBody))
         .andExpect(status().isOk());
-    verify(authService).verifyEmail(captor.capture());
-    EmailVerifyDto capturedDto = captor.getValue();
+
+    ArgumentCaptor<EmailDto> captor = ArgumentCaptor.forClass(EmailDto.class);
+    verify(authService).sendVerificationCode(captor.capture());
+    EmailDto capturedDto = captor.getValue();
 
     assertEquals("test@test.com", capturedDto.getEmail());
-    assertEquals("123456", capturedDto.getCode());
   }
 
   @Test

--- a/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
@@ -16,11 +16,33 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import homes.banzzokee.domain.auth.dto.EmailDto;
+import homes.banzzokee.global.util.redis.RedisService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
   @Mock
+  private JavaMailSender mailSender;
+
+  @Mock
   private RedisService redisService;
+
+  @Captor
+  private ArgumentCaptor<String> captor;
 
   @Mock
   private UserRepository userRepository;
@@ -32,8 +54,8 @@ class AuthServiceTest {
   @DisplayName("이메일 인증 테스트 - 성공 케이스")
   void successVerifyEmail() {
     // given
-    String email = "test@test.com" ;
-    String code = "123456" ;
+    String email = "test@test.com";
+    String code = "123456";
     EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
         .email("test@test.com")
         .code("123456")
@@ -52,8 +74,8 @@ class AuthServiceTest {
   @DisplayName("이메일 인증 테스트 - 실패 케이스 (코드 불일치)")
   void failVerifyEmailCodeUnmatched() {
     // given
-    String email = "test@test.com" ;
-    String code = "123456" ;
+    String email = "test@test.com";
+    String code = "123456";
     EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
         .email(email)
         .code(code)
@@ -68,8 +90,8 @@ class AuthServiceTest {
   @DisplayName("이메일 인증 테스트 - 실패 케이스 (코드 없음)")
   void failVerifyEmailCodeInvalid() {
     // given
-    String email = "test@test.com" ;
-    String code = "123456" ;
+    String email = "test@test.com";
+    String code = "123456";
     EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
         .email(email)
         .code(code)
@@ -83,7 +105,7 @@ class AuthServiceTest {
   @DisplayName("닉네임 중복확인 테스트 - 성공 케이스")
   void successCheckNickname() {
     // given
-    String nickname = "반쪽이" ;
+    String nickname = "반쪽이";
     when(userRepository.existsByNickname(nickname)).thenReturn(true);
 
     // when
@@ -97,7 +119,7 @@ class AuthServiceTest {
   @DisplayName("닉네임 중복확인 테스트 - 실패 케이스")
   void failCheckNickname() {
     // given
-    String nickname = "반쪽이" ;
+    String nickname = "반쪽이";
     when(userRepository.existsByNickname(nickname)).thenReturn(false);
 
     // when
@@ -105,5 +127,22 @@ class AuthServiceTest {
 
     // then
     assertTrue(result);
+  }
+
+  @DisplayName("이메일 인증 발송 테스트")
+  void successSendVerificationCode() {
+    // given
+    String email = "test@test.com";
+    EmailDto emailDto = EmailDto.builder()
+        .email(email)
+        .build();
+
+    // when
+    authService.sendVerificationCode(emailDto);
+
+    // then
+    verify(redisService, times(1)).setData(captor.capture(), any(String.class), any(Long.class));
+    assertEquals("test@test.com", captor.getValue());
+    verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
   }
 }


### PR DESCRIPTION
## Changes
- 내 이메일에 인증코드 6자리 전송하는 API 를 작성했습니다.

## Background
- 자사 회원가입 시 이메일 인증코드를 인증하기 위해 필요합니다.

## Issues
#42 

## Execute
- [x] postman API
- [x] tesc code 
<img width="1112" alt="send-verify-auth-test" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/095ac454-5d0a-4046-b99b-196a1718ca3e">

## Reference
- SMTP 자동 주입 불가 오류해결
- https://velog.io/@leesomyoung/SpringBoot-JavaMailSender-%EC%9E%90%EB%8F%99-%EC%A3%BC%EC%9E%85-%EB%B6%88%EA%B0%80-%EC%98%A4%EB%A5%98