### PR TITLE
feature: verify auth

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/config/MailConfig.java
+++ b/src/main/java/homes/banzzokee/domain/auth/config/MailConfig.java
@@ -1,0 +1,46 @@
+package homes.banzzokee.domain.auth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+  @Value("${spring.mail.host}")
+  private String host;
+
+  @Value("${spring.mail.port}")
+  private int port;
+
+  @Value("${spring.mail.username}")
+  private String username;
+
+  @Value("${spring.mail.password}")
+  private String password;
+
+  @Value("${spring.mail.properties.mail.smtp.auth}")
+  private String auth;
+
+  @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+  private String enable;
+
+  @Bean
+  public JavaMailSender getJavaMailSender() {
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+    mailSender.setHost(host);
+    mailSender.setPort(port);
+    mailSender.setUsername(username);
+    mailSender.setPassword(password);
+    Properties properties = mailSender.getJavaMailProperties();
+    properties.put("mail.transport.protocol", "smtp");
+    properties.put("mail.smtp.auth", auth);
+    properties.put("mail.smtp.starttls.enable", enable);
+    properties.put("mail.debug", "true");
+    return mailSender;
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package homes.banzzokee.domain.auth.controller;
 
+import homes.banzzokee.domain.auth.dto.EmailDto;
 import homes.banzzokee.domain.auth.dto.SignupDto;
 import homes.banzzokee.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
@@ -20,6 +21,12 @@ public class AuthController {
   @PostMapping("/sign-up")
   public ResponseEntity<Void> signup(@Valid @RequestBody SignupDto signupDto) {
     return ResponseEntity.ok().body(authService.signup(signupDto));
+  }
+
+  @PostMapping("/send-verify")
+  public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody EmailDto emailDto) {
+    authService.sendVerificationCode(emailDto);
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package homes.banzzokee.domain.auth.controller;
+
+import homes.banzzokee.domain.auth.dto.SignupDto;
+import homes.banzzokee.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/sign-up")
+  public ResponseEntity<Void> signup(@Valid @RequestBody SignupDto signupDto) {
+    return ResponseEntity.ok().body(authService.signup(signupDto));
+  }
+
+}

--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package homes.banzzokee.domain.auth.controller;
 
 import homes.banzzokee.domain.auth.dto.EmailDto;
 import homes.banzzokee.domain.auth.dto.SignupDto;
+import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
 import homes.banzzokee.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,16 +13,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
 
   private final AuthService authService;
 
-  @PostMapping("/sign-up")
-  public ResponseEntity<Void> signup(@Valid @RequestBody SignupDto signupDto) {
-    return ResponseEntity.ok().body(authService.signup(signupDto));
-  }
+//  @PostMapping("/sign-up")
+//  public ResponseEntity<Void> signup(@Valid @RequestBody SignupDto signupDto) {
+//    return ResponseEntity.ok().body(authService.signup(signupDto));
+//  }
 
   @PostMapping("/send-verify")
   public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody EmailDto emailDto) {
@@ -29,4 +30,9 @@ public class AuthController {
     return ResponseEntity.ok().build();
   }
 
+  @PostMapping("/verify")
+  public ResponseEntity<?> verifyEmail(@Valid @RequestBody EmailVerifyDto emailVerifyDto) {
+    authService.verifyEmail(emailVerifyDto);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/homes/banzzokee/domain/auth/dto/EmailDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/EmailDto.java
@@ -1,0 +1,18 @@
+package homes.banzzokee.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EmailDto {
+
+  @NotBlank(message = "email 은 필수 입력 항목입니다.")
+  @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "올바른 이메일 형식을 입력해주세요.")
+  private String email;
+
+}

--- a/src/main/java/homes/banzzokee/domain/auth/dto/EmailVerifyDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/EmailVerifyDto.java
@@ -7,8 +7,9 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
 /**
- * 이메일 인증 요청
+ * 이메일 인증 요청 dto
  *
  * @param email
  * @param code

--- a/src/main/java/homes/banzzokee/domain/auth/dto/EmailVerifyDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/EmailVerifyDto.java
@@ -2,19 +2,28 @@ package homes.banzzokee.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+/**
+ * 이메일 인증 요청
+ *
+ * @param email
+ * @param code
+ */
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class EmailDto {
+public class EmailVerifyDto {
 
   @NotBlank(message = "email 은 필수 입력 항목입니다.")
   @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "올바른 이메일 형식을 입력해주세요.")
   private String email;
+
+  @NotBlank(message = "인증 코드는 필수 입력 항목입니다.")
+  @Pattern(regexp = "\\d{6}", message = "인증 코드는 6자리 숫자여야 합니다.")
+  private String code;
 
 }

--- a/src/main/java/homes/banzzokee/domain/auth/dto/SignupDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/SignupDto.java
@@ -1,0 +1,41 @@
+package homes.banzzokee.domain.auth.dto;
+
+import homes.banzzokee.domain.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignupDto {
+
+  @NotBlank(message = "email 은 필수 입력 항목입니다.")
+  @Email(message = "올바른 이메일 형식을 입력해주세요.")
+  @Pattern(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")
+  private String email;
+
+  @NotBlank(message = "password 는 필수 입력 항목입니다.")
+  @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()-_=+]).{8,20}$",
+      message = "password 는 소문자, 대문자, 숫자, 특수문자 각각 최소 1개 이상을 포함하는 8자리 이상 20자리 이하로 설정해야 합니다.")
+  private String password;
+
+  @NotBlank(message = "password 확인은 필수 입력 항목입니다.")
+  private String confirmPassword;
+
+  @Size(max = 10, message = "nickname 은 10자리 이내로 작성해주세요.")
+  @NotBlank(message = "nickname 은 필수 입력 항목입니다.")
+  private String nickname;
+
+  public User toEntity() {
+    return User.builder()
+        .email(this.email)
+        .password(this.password)
+        .nickname(this.nickname)
+        .build();
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/auth/dto/SignupDto.java
+++ b/src/main/java/homes/banzzokee/domain/auth/dto/SignupDto.java
@@ -15,8 +15,7 @@ import lombok.Getter;
 public class SignupDto {
 
   @NotBlank(message = "email 은 필수 입력 항목입니다.")
-  @Email(message = "올바른 이메일 형식을 입력해주세요.")
-  @Pattern(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")
+  @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "올바른 이메일 형식을 입력해주세요.")
   private String email;
 
   @NotBlank(message = "password 는 필수 입력 항목입니다.")

--- a/src/main/java/homes/banzzokee/domain/auth/exception/EmailCodeInvalidException.java
+++ b/src/main/java/homes/banzzokee/domain/auth/exception/EmailCodeInvalidException.java
@@ -1,0 +1,12 @@
+package homes.banzzokee.domain.auth.exception;
+
+import homes.banzzokee.global.error.exception.CustomException;
+
+import static homes.banzzokee.global.error.ErrorCode.EMAIL_CODE_INVALID;
+
+public class EmailCodeInvalidException extends CustomException {
+
+  public EmailCodeInvalidException() {
+    super(EMAIL_CODE_INVALID);
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/auth/exception/EmailCodeUnmatchedException.java
+++ b/src/main/java/homes/banzzokee/domain/auth/exception/EmailCodeUnmatchedException.java
@@ -1,0 +1,12 @@
+package homes.banzzokee.domain.auth.exception;
+
+import homes.banzzokee.global.error.exception.CustomException;
+
+import static homes.banzzokee.global.error.ErrorCode.EMAIL_CODE_UNMATCHED;
+
+public class EmailCodeUnmatchedException extends CustomException {
+
+  public EmailCodeUnmatchedException() {
+    super(EMAIL_CODE_UNMATCHED);
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -1,27 +1,38 @@
 package homes.banzzokee.domain.auth.service;
 
 import homes.banzzokee.domain.auth.dto.EmailDto;
+import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
 import homes.banzzokee.domain.auth.dto.SignupDto;
+import homes.banzzokee.domain.auth.exception.EmailCodeInvalidException;
+import homes.banzzokee.domain.auth.exception.EmailCodeUnmatchedException;
 import homes.banzzokee.domain.user.dao.UserRepository;
+import homes.banzzokee.global.error.exception.CustomException;
+import homes.banzzokee.global.util.redis.RedisService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-  private static final String EMAIL_SUBJECT = "인증 코드";
-  private static final String EMAIL_TEXT = "인증 코드는 %s 입니다.";
+  private static final String EMAIL_SUBJECT = "인증 코드" ;
+  private static final String EMAIL_TEXT = "인증 코드는 %s 입니다." ;
+  private static final int VERIFICATION_CODE_EXPIRATION_TIME = 3;
+  private static final int VERIFICATION_CODE_MIN_VALUE = 100000;
+  private static final int VERIFICATION_CODE_MAX_VALUE = 900000;
 
-  private JavaMailSender mailSender;
-  private StringRedisTemplate redisTemplate;
-
+  private final JavaMailSender mailSender;
+  private final RedisService redisService;
   private final UserRepository userRepository;
 
   public void signup(SignupDto signupDto) {
@@ -30,7 +41,7 @@ public class AuthService {
 
   public void sendVerificationCode(EmailDto emailDto) {
     String code = generateVerificationCode();
-    redisTemplate.opsForValue().set(emailDto.getEmail(), code, Duration.ofMinutes(3));
+    redisService.setData(emailDto.getEmail(), code, Duration.ofMinutes(VERIFICATION_CODE_EXPIRATION_TIME).getSeconds());
     SimpleMailMessage message = new SimpleMailMessage();
     message.setTo(emailDto.getEmail());
     message.setSubject(EMAIL_SUBJECT);
@@ -39,7 +50,19 @@ public class AuthService {
   }
 
   private String generateVerificationCode() {
-    return String.valueOf(100000 + new Random().nextInt(900000));
+    return String.valueOf(VERIFICATION_CODE_MIN_VALUE + new Random().nextInt(VERIFICATION_CODE_MAX_VALUE));
   }
 
+  public void verifyEmail(EmailVerifyDto emailVerifyDto) {
+    String email = emailVerifyDto.getEmail();
+    String code = emailVerifyDto.getCode();
+    String redisCode = (String) redisService.getData(email);
+    if (redisCode == null) {
+      throw new EmailCodeUnmatchedException();
+    }
+    if (!Objects.equals(redisCode, code)) {
+      throw new EmailCodeInvalidException();
+    }
+    redisService.deleteKey(email);
+  }
 }

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -1,17 +1,45 @@
 package homes.banzzokee.domain.auth.service;
 
+import homes.banzzokee.domain.auth.dto.EmailDto;
 import homes.banzzokee.domain.auth.dto.SignupDto;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+  private static final String EMAIL_SUBJECT = "인증 코드";
+  private static final String EMAIL_TEXT = "인증 코드는 %s 입니다.";
+
+  private JavaMailSender mailSender;
+  private StringRedisTemplate redisTemplate;
 
   private final UserRepository userRepository;
 
   public void signup(SignupDto signupDto) {
 
   }
+
+  public void sendVerificationCode(EmailDto emailDto) {
+    String code = generateVerificationCode();
+    redisTemplate.opsForValue().set(emailDto.getEmail(), code, Duration.ofMinutes(3));
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setTo(emailDto.getEmail());
+    message.setSubject(EMAIL_SUBJECT);
+    message.setText(String.format(EMAIL_TEXT, code));
+    mailSender.send(message);
+  }
+
+  private String generateVerificationCode() {
+    return String.valueOf(100000 + new Random().nextInt(900000));
+  }
+
 }

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -1,0 +1,17 @@
+package homes.banzzokee.domain.auth.service;
+
+import homes.banzzokee.domain.auth.dto.SignupDto;
+import homes.banzzokee.domain.user.dao.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+
+  public void signup(SignupDto signupDto) {
+
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -6,18 +6,14 @@ import homes.banzzokee.domain.auth.dto.SignupDto;
 import homes.banzzokee.domain.auth.exception.EmailCodeInvalidException;
 import homes.banzzokee.domain.auth.exception.EmailCodeUnmatchedException;
 import homes.banzzokee.domain.user.dao.UserRepository;
-import homes.banzzokee.global.error.exception.CustomException;
 import homes.banzzokee.global.util.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Random;
 
 @Slf4j
@@ -60,7 +56,7 @@ public class AuthService {
     if (redisCode == null) {
       throw new EmailCodeUnmatchedException();
     }
-    if (!Objects.equals(redisCode, code)) {
+    if (!code.equals(redisCode)) {
       throw new EmailCodeInvalidException();
     }
     redisService.deleteKey(email);

--- a/src/main/java/homes/banzzokee/global/config/redis/RedisConfig.java
+++ b/src/main/java/homes/banzzokee/global/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package homes.banzzokee.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    final RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory());
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    return template;
+  }
+}

--- a/src/main/java/homes/banzzokee/global/error/ErrorCode.java
+++ b/src/main/java/homes/banzzokee/global/error/ErrorCode.java
@@ -13,6 +13,9 @@ public enum ErrorCode {
 
   FAILED(BAD_REQUEST, "실패했습니다."),
   USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+  EMAIL_CODE_UNMATCHED(BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+  EMAIL_CODE_INVALID(BAD_REQUEST, "인증 코드가 유효하지 않습니다."),
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
+++ b/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
@@ -1,0 +1,35 @@
+package homes.banzzokee.global.util.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedisService {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public RedisService(RedisTemplate<String, Object> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public void setData(String key, Object value, long duration) {
+    redisTemplate.opsForValue().set(key, value, duration, TimeUnit.SECONDS);
+  }
+
+  public void setDataExpire(String key, Object value, long duration) {
+    ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(key, value, duration, TimeUnit.SECONDS);
+  }
+
+  public Object getData(String key) {
+    ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+    return valueOperations.get(key);
+  }
+
+  public void deleteKey(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379

--- a/src/main/resources/application-smtp.yml
+++ b/src/main/resources/application-smtp.yml
@@ -1,0 +1,12 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_EMAIL}
+    password: ${GOOGLE_EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,4 @@ server:
 
 spring:
   profiles:
-    include: jpa
+    include: jpa, smtp, redis

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,64 @@
+package homes.banzzokee.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
+import homes.banzzokee.domain.auth.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private AuthService authService;
+
+  @Captor
+  private ArgumentCaptor<EmailVerifyDto> captor;
+
+  @Test
+  @DisplayName("이메일 인증 성공 테스트")
+  void successVerifyEmail() throws Exception {
+    // given
+    String email = "test@test.com" ;
+    String code = "123456" ;
+    EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
+        .email(email)
+        .code(code)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(emailVerifyDto);
+
+    // when & then
+    mockMvc.perform(post("/api/auth/verify")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody))
+        .andExpect(status().isOk());
+    verify(authService).verifyEmail(captor.capture());
+    EmailVerifyDto capturedDto = captor.getValue();
+
+    assertEquals("test@test.com", capturedDto.getEmail());
+    assertEquals("123456", capturedDto.getCode());
+  }
+}

--- a/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,78 @@
+package homes.banzzokee.domain.auth.service;
+
+import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
+import homes.banzzokee.domain.auth.exception.EmailCodeInvalidException;
+import homes.banzzokee.domain.auth.exception.EmailCodeUnmatchedException;
+import homes.banzzokee.global.util.redis.RedisService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private RedisService redisService;
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Test
+  @DisplayName("이메일 인증 테스트 - 성공 케이스")
+  void successVerifyEmail() {
+    // given
+    String email = "test@test.com" ;
+    String code = "123456" ;
+    EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
+        .email("test@test.com")
+        .code("123456")
+        .build();
+
+    when(redisService.getData(email)).thenReturn(code);
+
+    // when
+    assertDoesNotThrow(() -> authService.verifyEmail(emailVerifyDto));
+
+    // then
+    verify(redisService).deleteKey(email);
+  }
+
+  @Test
+  @DisplayName("이메일 인증 테스트 - 실패 케이스 (코드 불일치)")
+  void failVerifyEmailCodeUnmatched() {
+    // given
+    String email = "test@test.com" ;
+    String code = "123456" ;
+    EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
+        .email(email)
+        .code(code)
+        .build();
+    when(redisService.getData(email)).thenReturn(email);
+
+    // when & then
+    assertThrows(EmailCodeInvalidException.class, () -> authService.verifyEmail(emailVerifyDto));
+  }
+
+  @Test
+  @DisplayName("이메일 인증 테스트 - 실패 케이스 (코드 없음)")
+  void failVerifyEmailCodeInvalid() {
+    // given
+    String email = "test@test.com" ;
+    String code = "123456" ;
+    EmailVerifyDto emailVerifyDto = EmailVerifyDto.builder()
+        .email(email)
+        .code(code)
+        .build();
+    when(redisService.getData(email)).thenReturn(null);
+
+    // when & then
+    assertThrows(EmailCodeUnmatchedException.class, () -> authService.verifyEmail(emailVerifyDto));
+  }
+}


### PR DESCRIPTION
## Changes
- 이메일 검증 및 인증 코드 검증 하는 API 를 작성했습니다.
- reids 를 활용하여 이메일을 key 값으로 저장해서 인증 코드를 저장하게 해놨습니다.
- 이메일 인증 및 인증 코드 통과 시 redis 에서 자동 삭제 되도록 하였습니다.
- 인증 코드는 3분간 유효 하도록 하였습니다.

## Background
- 자사 회원가입 시 이메일 인증코드를 인증하기 위해 필요합니다.

## Issues
#43  

## Execute
- [x] postman
- [x] test code
<img width="500" alt="이메일_다를_경우_예외" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/478ae5dd-f65e-4c75-b504-d75002573500">
<img width="500" alt="인증코드_다르거나_없을때_예외" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/e343a7ec-2a7f-4330-a581-d268eb6e50b0">
<img width="500" alt="verify_redis_test" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/4564e8e9-3e0f-408c-8f9b-39e2449beaca">
