### PR TITLE
feature: nickname check auth

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -1,16 +1,13 @@
 package homes.banzzokee.domain.auth.controller;
 
 import homes.banzzokee.domain.auth.dto.EmailDto;
-import homes.banzzokee.domain.auth.dto.SignupDto;
 import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
 import homes.banzzokee.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +31,11 @@ public class AuthController {
   public ResponseEntity<?> verifyEmail(@Valid @RequestBody EmailVerifyDto emailVerifyDto) {
     authService.verifyEmail(emailVerifyDto);
     return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/nickname-check")
+  public ResponseEntity<?> checkNickname(
+      @Length(max = 10, message = "닉네임은 최대 10자리까지 가능합니다.") @RequestParam String nickname) {
+    return ResponseEntity.ok(authService.checkNickname(nickname));
   }
 }

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -61,4 +61,8 @@ public class AuthService {
     }
     redisService.deleteKey(email);
   }
+
+  public boolean checkNickname(String nickname) {
+    return !userRepository.existsByNickname(nickname);
+  }
 }

--- a/src/main/java/homes/banzzokee/domain/user/dao/UserRepository.java
+++ b/src/main/java/homes/banzzokee/domain/user/dao/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  boolean existsByNickname(String nickname);
+
 }

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -21,6 +21,16 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -60,5 +70,39 @@ class AuthControllerTest {
 
     assertEquals("test@test.com", capturedDto.getEmail());
     assertEquals("123456", capturedDto.getCode());
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("닉네임 중복확인 테스트 - 성공 케이스")
+  void successCheckNickname() throws Exception {
+    // given
+    String nickname = "반쪽이" ;
+    when(authService.checkNickname(nickname)).thenReturn(true);
+
+    // when & then
+    mockMvc.perform(get("/api/auth/nickname-check")
+            .param("nickname", nickname))
+        .andExpect(status().isOk())
+        .andExpect(content().string("true"));
+
+    verify(authService, times(1)).checkNickname("반쪽이");
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("닉네임 중복확인 테스트 - 실패 케이스")
+  void failCheckNickname() throws Exception {
+    //given
+    String nickname = "반쪽이" ;
+    when(authService.checkNickname(nickname)).thenReturn(false);
+
+    //when & then
+    mockMvc.perform(get("/api/auth/nickname-check")
+            .param("nickname", nickname))
+        .andExpect(status().isOk())
+        .andExpect(content().string("false"));
+
+    verify(authService, times(1)).checkNickname("반쪽이");
   }
 }

--- a/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import homes.banzzokee.domain.auth.dto.EmailVerifyDto;
 import homes.banzzokee.domain.auth.exception.EmailCodeInvalidException;
 import homes.banzzokee.domain.auth.exception.EmailCodeUnmatchedException;
 import homes.banzzokee.global.util.redis.RedisService;
+import homes.banzzokee.domain.user.dao.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,9 @@ class AuthServiceTest {
 
   @Mock
   private RedisService redisService;
+
+  @Mock
+  private UserRepository userRepository;
 
   @InjectMocks
   private AuthService authService;
@@ -74,5 +78,32 @@ class AuthServiceTest {
 
     // when & then
     assertThrows(EmailCodeUnmatchedException.class, () -> authService.verifyEmail(emailVerifyDto));
+  }
+
+  @DisplayName("닉네임 중복확인 테스트 - 성공 케이스")
+  void successCheckNickname() {
+    // given
+    String nickname = "반쪽이" ;
+    when(userRepository.existsByNickname(nickname)).thenReturn(true);
+
+    // when
+    boolean result = !authService.checkNickname("반쪽이");
+
+    // then
+    assertTrue(result);
+  }
+
+  @Test
+  @DisplayName("닉네임 중복확인 테스트 - 실패 케이스")
+  void failCheckNickname() {
+    // given
+    String nickname = "반쪽이" ;
+    when(userRepository.existsByNickname(nickname)).thenReturn(false);
+
+    // when
+    boolean result = authService.checkNickname("반쪽이");
+
+    // then
+    assertTrue(result);
   }
 }


### PR DESCRIPTION
## Changes
- 회원가입 시 nickname 중복 확인 API 추가 하였습니다.
- 중복 시 true 반환 & 중복이 아닐 시 false 반환하도록 하였습니다.

## Background
- 자사 회원가입 시 닉네임 중복 확인을 위해 필요합니다.

## Issues
#44 

## Execute
- [x] postman
- [x] test code
<img width="1024" alt="nickname_duplicate_check" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/537c0c66-8358-41c3-b1ac-4ccb681139c0">
