### PR TITLE
feature: 특정 유저에게만 채팅메세지 전송

### DIFF
--- a/src/main/java/homes/banzzokee/domain/chat/controller/MessageController.java
+++ b/src/main/java/homes/banzzokee/domain/chat/controller/MessageController.java
@@ -3,10 +3,12 @@ package homes.banzzokee.domain.chat.controller;
 import homes.banzzokee.domain.chat.dto.MessageDto;
 import homes.banzzokee.domain.chat.dto.SendChatDto;
 import homes.banzzokee.domain.chat.service.ChatMessageService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,9 +32,13 @@ public class MessageController {
   @MessageMapping("/chats/rooms/{roomId}")
   // /api/chats/rooms/{roomId} 로 메세지 전송 요청
   @SendTo("/queue/chats/rooms/{roomId}")  // subscribe destination
-  public MessageDto sendMessage(@DestinationVariable("roomId") Long roomId,
-      SendChatDto message) {
-    log.info("[sendMessage] roomId : {}", roomId);
+  public MessageDto sendMessage(
+      Principal principal,
+      @DestinationVariable("roomId") Long roomId,
+      @Payload SendChatDto message) {
+
+    log.info("[sendMessage] room id : {}, user-id: '{}'", roomId,
+        principal.getName());
 
     return chatMessageService.sendMessage(roomId, message);
   }

--- a/src/main/java/homes/banzzokee/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/homes/banzzokee/domain/chat/service/ChatMessageService.java
@@ -1,7 +1,8 @@
 package homes.banzzokee.domain.chat.service;
 
 import static homes.banzzokee.domain.type.MessageType.ENTER;
-import static homes.banzzokee.global.error.ErrorCode.FAILED;
+import static homes.banzzokee.global.error.ErrorCode.ROOM_NOT_FOUND;
+import static homes.banzzokee.global.error.ErrorCode.USER_NOT_FOUND;
 
 import homes.banzzokee.domain.chat.dao.ChatMessageRepository;
 import homes.banzzokee.domain.chat.dto.MessageDto;
@@ -11,7 +12,7 @@ import homes.banzzokee.domain.room.dao.ChatRoomRepository;
 import homes.banzzokee.domain.room.entity.ChatRoom;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.entity.User;
-import homes.banzzokee.global.error.exception.CustomException;
+import homes.banzzokee.global.config.stomp.exception.SocketException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -40,14 +41,13 @@ public class ChatMessageService {
    */
   public MessageDto sendMessage(Long roomId, SendChatDto message) {
 
-    // todo: FAILED -> ROOM_NOT_FOUND
     ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-        .orElseThrow(() -> new CustomException(FAILED));
+        .orElseThrow(() -> new SocketException(ROOM_NOT_FOUND));
 
     // todo: FAILED -> USER_NOT_FOUND
     // todo: @AuthenticationPrincipal username -> findByEmail(email) 로 변경
     User user = userRepository.findById(1L)
-        .orElseThrow(() -> new CustomException(FAILED));
+        .orElseThrow(() -> new SocketException(USER_NOT_FOUND));
 
     String realMessage = message.messageType().equals(ENTER) ?
         user.getNickname() + " 님이 입장하였습니다." :
@@ -73,9 +73,8 @@ public class ChatMessageService {
   @Transactional(readOnly = true)
   public Slice<MessageDto> getChatList(Long roomId, Pageable pageable) {
 
-    // todo: FAILED -> ROOM_NOT_FOUND
     ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-        .orElseThrow(() -> new CustomException(FAILED));
+        .orElseThrow(() -> new SocketException(ROOM_NOT_FOUND));
 
     return chatMessageRepository.findAllByRoom(chatRoom, pageable)
         .map(MessageDto::fromEntity);

--- a/src/main/java/homes/banzzokee/global/config/stomp/StompWebSocketConfig.java
+++ b/src/main/java/homes/banzzokee/global/config/stomp/StompWebSocketConfig.java
@@ -1,5 +1,7 @@
 package homes.banzzokee.global.config.stomp;
 
+import homes.banzzokee.global.config.stomp.handler.CustomHandshakeHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -11,21 +13,27 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
  */
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final CustomHandshakeHandler customHandshakeHandler;
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws-stomp")
         // ws://localhost:8080/ws-stomp 로 연결
-        .setAllowedOriginPatterns("*");
+        .setAllowedOriginPatterns("*")
+        .setHandshakeHandler(customHandshakeHandler) // Websocket hand-shake
+        .withSockJS(); // SockJs 사용 가능 설정
+    // http://localhost:8080/ws-stomp 로 연결 가능
   }
 
   @Override
-  public void configureMessageBroker(MessageBrokerRegistry config) {
-    config.enableSimpleBroker("/queue", "/topic");
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/queue", "/topic");
     // 구독 요청 /queue 는 1:1, /topic 은 1:N
 
-    config.setApplicationDestinationPrefixes("/api");
+    registry.setApplicationDestinationPrefixes("/api");
     // client -> server 로 메세지 전송 요청할때 쓰일 접두사
     // MessageController 에서 쓰임 확인
   }

--- a/src/main/java/homes/banzzokee/global/config/stomp/exception/SocketException.java
+++ b/src/main/java/homes/banzzokee/global/config/stomp/exception/SocketException.java
@@ -1,0 +1,14 @@
+package homes.banzzokee.global.config.stomp.exception;
+
+import homes.banzzokee.global.error.ErrorCode;
+import homes.banzzokee.global.error.exception.CustomException;
+
+/**
+ * WebSocket 에러 처리를 위한 Exception
+ */
+public class SocketException extends CustomException {
+
+  public SocketException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/homes/banzzokee/global/config/stomp/handler/CustomHandshakeHandler.java
+++ b/src/main/java/homes/banzzokee/global/config/stomp/handler/CustomHandshakeHandler.java
@@ -1,0 +1,30 @@
+package homes.banzzokee.global.config.stomp.handler;
+
+import homes.banzzokee.global.config.stomp.principal.StompPrincipal;
+import java.security.Principal;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+/**
+ * WebSocket HandshakeHandler 메세지를 전송할때 handshake 진행
+ */
+@Slf4j
+@Configuration
+public class CustomHandshakeHandler extends DefaultHandshakeHandler {
+
+  // 메세지를 전송한 유저 name 반환
+  @Override
+  protected Principal determineUser(ServerHttpRequest request,
+      WebSocketHandler wsHandler,
+      Map<String, Object> attributes) {
+
+    return new StompPrincipal(
+        UUID.randomUUID().toString()); // random 유저 고유 id 생성
+
+  }
+}

--- a/src/main/java/homes/banzzokee/global/config/stomp/principal/StompPrincipal.java
+++ b/src/main/java/homes/banzzokee/global/config/stomp/principal/StompPrincipal.java
@@ -1,0 +1,20 @@
+package homes.banzzokee.global.config.stomp.principal;
+
+import java.security.Principal;
+
+/**
+ * STOMP 접근 유저 name
+ */
+public class StompPrincipal implements Principal {
+
+  private String name;
+
+  public StompPrincipal(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/homes/banzzokee/global/error/ErrorCode.java
+++ b/src/main/java/homes/banzzokee/global/error/ErrorCode.java
@@ -24,6 +24,10 @@ public enum ErrorCode {
   EMAIL_CODE_UNMATCHED(BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
   EMAIL_CODE_INVALID(BAD_REQUEST, "인증 코드가 유효하지 않습니다."),
 
+  // chat & room
+  ROOM_NOT_FOUND(NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+  ;
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/homes/banzzokee/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/homes/banzzokee/global/error/GlobalExceptionHandler.java
@@ -1,10 +1,14 @@
 package homes.banzzokee.global.error;
 
+import homes.banzzokee.global.config.stomp.exception.SocketException;
 import homes.banzzokee.global.error.exception.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -14,8 +18,24 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
-  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
-    log.error("[CustomException] {} is occurred. uri:{}", e.getErrorCode(), request.getRequestURI());
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e,
+      HttpServletRequest request) {
+    log.error("[CustomException] {} is occurred. uri:{}", e.getErrorCode(),
+        request.getRequestURI());
+
+    return ResponseEntity
+        .status(e.getErrorCode().getHttpStatus())
+        .body(
+            ErrorResponse.of(e.getErrorCode())
+        );
+  }
+
+  @MessageExceptionHandler  // 메세지 전송 에러 핸들러
+  @SendToUser("/queue/error") // 특정 유저에게 메세지 전송 ->
+  // "/user/queue/error" 구독한 유저
+  public ResponseEntity<ErrorResponse> handleException(
+      Principal principal,  // 쓰이지 않더라도 파라미터로 받아와야 특정한 유저에게 보낼 수 있음
+      SocketException e) {
 
     return ResponseEntity
         .status(e.getErrorCode().getHttpStatus())


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
1. MessageController 수정
   - `MessageExceptionHandler` 메서드 추가
   - @ `SendToUser` 어노테이션 설정
      - "/queue/error" 를 구독하는 유저에게 메세지 전송
      - 클라이언트에서는 `"/user/queue/error"` 를 `구독`해야 정상적으로 작동됨
      - `Principal` 객체를 파라미터로 받아야 특정한 유저에게만 전송됨
   - 서비스 로직에서 throw 하는 Exception을 받아들여 처리한다.
2. `SocketException` 추가
   - 채팅 에러처리만을 위한 `SocketException` 추가 -> `CustomException` 상속
3. `CustomHandshakeHandler` 추가
   - `HandshakeHandler`를 통해 채팅 기능 접근 유저에 대한 정보를 얻는다.
   - Security의 `Principal` 클래스에 `유저 name` 을 저장한다.
4. StompWebSocketConfig
   - customHandshakeHandler 등록
   - withSockJs() 로 `ws://` 접근을 `http://` 접근으로 변경

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
채팅 기능에 잘못 접근한 유저에 대한 에러 핸들링을 할때 같은 채널을 구독하는 모든 유저에게 같은 에러가 가게 된다.
잘못 접근한 유저에게만 에러 메세지가 가도록 코드 수정이 필요했다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->
서비스 로직 내에서의 에러 처리는 가능해졌는데,
STOMP 소켓 연결, 채널 구독에 대한 에러 핸들링을 구현중입니다.

## Issues
해결한 이슈: #50

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
![send-to-user-test](https://github.com/banzzokee/banzzokee-back/assets/47658862/72c309fc-3842-4772-bc13-b6632cc924df)


## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
[Principal 추가](https://withseungryu.tistory.com/136)
[@ SendToUser 해결](https://ksr930.tistory.com/320)
[전체적인 STOMP 개념 상세](https://velog.io/@koseungbin/WebSocket#stomp)
