### PR TITLE
feature: delete shelter

### DIFF
--- a/src/main/java/homes/banzzokee/domain/room/dao/ChatRoomRepository.java
+++ b/src/main/java/homes/banzzokee/domain/room/dao/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package homes.banzzokee.domain.room.dao;
 
 import homes.banzzokee.domain.room.entity.ChatRoom;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
+  List<ChatRoom> findAllByShelterId(long shelterId);
 }

--- a/src/main/java/homes/banzzokee/domain/room/entity/ChatRoom.java
+++ b/src/main/java/homes/banzzokee/domain/room/entity/ChatRoom.java
@@ -58,4 +58,7 @@ public class ChatRoom {
 //    this.adoption = adoption;
   }
 
+  public void leaveShelter() {
+    this.shelter = null;
+  }
 }

--- a/src/main/java/homes/banzzokee/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/controller/ShelterController.java
@@ -7,6 +7,7 @@ import homes.banzzokee.domain.shelter.service.ShelterService;
 import homes.banzzokee.global.validator.annotation.ImageFile;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +44,11 @@ public class ShelterController {
       @ImageFile MultipartFile shelterImg, @RequestParam long userId) {
     // TODO: userId -> @AuthenticationPrincipal 바꾸기
     return shelterService.updateShelter(shelterId, request, shelterImg, userId);
+  }
+
+  @DeleteMapping("{shelterId}")
+  public void unregisterShelter(@PathVariable long shelterId, @RequestParam long userId) {
+    // TODO: userId -> @AuthenticationPrincipal 바꾸기
+    shelterService.unregisterShelter(shelterId, userId);
   }
 }

--- a/src/main/java/homes/banzzokee/domain/shelter/entity/Shelter.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/entity/Shelter.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
@@ -88,6 +89,8 @@ public class Shelter extends BaseEntity {
   @JoinColumn(name = "user_id")
   private final User user;
 
+  private LocalDateTime deletedAt;
+
   @Builder
   public Shelter(String name, String description, String shelterImgUrl, String tel,
       String address,
@@ -106,16 +109,33 @@ public class Shelter extends BaseEntity {
     }
   }
 
+  /**
+   * @return 보호소 이미지 경로
+   */
   public String getShelterImageUrl() {
     return this.getShelterImage() != null ? this.getShelterImage().getUrl() : null;
   }
 
+  /**
+   * 보호소 승인
+   */
   public void verify() {
     this.verified = true;
     assert this.user != null;
     this.user.addRoles(SHELTER);
   }
 
+  /**
+   * 보호소 정보 수정
+   *
+   * @param name         이름
+   * @param description  설명
+   * @param tel          연락처
+   * @param address      주소
+   * @param latitude     위도
+   * @param longitude    경도
+   * @param shelterImage 보호소 이미지
+   */
   public void updateProfile(String name, String description, String tel, String address,
       Double latitude, Double longitude, S3Object shelterImage) {
     this.name = name;
@@ -127,5 +147,30 @@ public class Shelter extends BaseEntity {
     if (shelterImage != null) {
       this.shelterImage = shelterImage;
     }
+  }
+
+  /**
+   * 보호소 삭제
+   */
+  public void delete() {
+    if (this.deletedAt == null) {
+      this.verified = false;
+      this.deletedAt = LocalDateTime.now();
+    }
+  }
+
+  /**
+   * @return 보호소 삭제 여부
+   */
+  public boolean isDeleted() {
+    return this.deletedAt != null;
+  }
+
+  /**
+   * 보호소 복구
+   */
+  public void restore() {
+    this.verified = false;
+    this.deletedAt = null;
   }
 }

--- a/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
@@ -17,7 +17,6 @@ import homes.banzzokee.domain.type.S3Object;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.entity.User;
 import homes.banzzokee.domain.user.exception.UserNotFoundException;
-import homes.banzzokee.global.error.exception.CustomException;
 import homes.banzzokee.global.error.exception.NoAuthorizedException;
 import homes.banzzokee.infra.fileupload.service.FileUploadService;
 import java.util.Objects;
@@ -39,9 +38,10 @@ public class ShelterService {
 
   /**
    * 보호소 등록
-   * @param request 보호소 등록 요청
+   *
+   * @param request    보호소 등록 요청
    * @param shelterImg 보호소 이미지
-   * @param userId 보호소를 등록할 사용자 아이디
+   * @param userId     보호소를 등록할 사용자 아이디
    */
   @Transactional
   public void registerShelter(ShelterRegisterRequest request, MultipartFile shelterImg,
@@ -57,8 +57,9 @@ public class ShelterService {
 
   /**
    * 보호소 승인
+   *
    * @param shelterId 승인할 보호소 아이디
-   * @param userId 보호소를 승인할 사용자 아이디
+   * @param userId    보호소를 승인할 사용자 아이디
    */
   @Transactional
   public void verifyShelter(long shelterId, long userId) {
@@ -73,10 +74,11 @@ public class ShelterService {
 
   /**
    * 보호소 정보 수정
-   * @param shelterId 수정할 보호소 아이디
-   * @param request 보호소 수정 요청
+   *
+   * @param shelterId    수정할 보호소 아이디
+   * @param request      보호소 수정 요청
    * @param shelterImage 보호소 이미지
-   * @param userId 보호소를 수정할 사용자 아이디
+   * @param userId       보호소를 수정할 사용자 아이디
    * @return 보호소 수정 응답
    */
   @Transactional
@@ -99,8 +101,9 @@ public class ShelterService {
 
   /**
    * 보호소 삭제
+   *
    * @param shelterId 삭제할 보호소 아이디
-   * @param userId 보호소를 삭제할 사용자 아이디
+   * @param userId    보호소를 삭제할 사용자 아이디
    */
   @Transactional
   public void unregisterShelter(long shelterId, long userId) {
@@ -119,7 +122,8 @@ public class ShelterService {
 
   /**
    * 보호소를 등록한 사용자가 아니라면 예외를 발생한다.
-   * @param user 확인할 사용자
+   *
+   * @param user    확인할 사용자
    * @param shelter 보호소
    */
   private void throwIfUserIsNotShelterUser(User user, Shelter shelter) {
@@ -130,6 +134,7 @@ public class ShelterService {
 
   /**
    * 보호소가 승인되지 않은 상태면 예외를 발생한다.
+   *
    * @param shelter 보호소
    */
   private void throwIfShelterNotVerified(Shelter shelter) {
@@ -140,6 +145,7 @@ public class ShelterService {
 
   /**
    * 사용자가 이미 승인된 보호소를 등록한 상태라면 예외를 발생한다.
+   *
    * @param user 사용자
    */
   private void throwIfUserAlreadyRegisterShelter(User user) {
@@ -151,6 +157,7 @@ public class ShelterService {
 
   /**
    * 사용자가 ADMIN 권한이 없으면 예외를 발생한다.
+   *
    * @param user 사용자
    */
   private void throwIfUserHasNotAdminRole(User user) {

--- a/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
@@ -1,8 +1,9 @@
 package homes.banzzokee.domain.shelter.service;
 
 import static homes.banzzokee.domain.type.Role.ADMIN;
-import static homes.banzzokee.global.error.ErrorCode.FAILED;
 
+import homes.banzzokee.domain.room.dao.ChatRoomRepository;
+import homes.banzzokee.domain.room.entity.ChatRoom;
 import homes.banzzokee.domain.shelter.dao.ShelterRepository;
 import homes.banzzokee.domain.shelter.dto.ShelterRegisterRequest;
 import homes.banzzokee.domain.shelter.dto.ShelterUpdateRequest;
@@ -33,8 +34,15 @@ public class ShelterService {
 
   private final UserRepository userRepository;
   private final ShelterRepository shelterRepository;
+  private final ChatRoomRepository chatRoomRepository;
   private final FileUploadService s3Service;
 
+  /**
+   * 보호소 등록
+   * @param request 보호소 등록 요청
+   * @param shelterImg 보호소 이미지
+   * @param userId 보호소를 등록할 사용자 아이디
+   */
   @Transactional
   public void registerShelter(ShelterRegisterRequest request, MultipartFile shelterImg,
       long userId) {
@@ -44,20 +52,14 @@ public class ShelterService {
     throwIfShelterNotVerified(user.getShelter());
 
     S3Object uploadedImage = uploadShelterImage(shelterImg);
-
-    user.registerShelter(Shelter.builder()
-        .name(request.getName())
-        .description(request.getDescription())
-        .tel(request.getTel())
-        .address(request.getAddress())
-        .latitude(request.getLatitude())
-        .longitude(request.getLongitude())
-        .shelterImgUrl(uploadedImage.getUrl())
-        .verified(false)
-        .user(user)
-        .build());
+    registerOrRestoreShelter(user, request, uploadedImage);
   }
 
+  /**
+   * 보호소 승인
+   * @param shelterId 승인할 보호소 아이디
+   * @param userId 보호소를 승인할 사용자 아이디
+   */
   @Transactional
   public void verifyShelter(long shelterId, long userId) {
     User user = findByUserIdOrThrow(userId);
@@ -69,6 +71,14 @@ public class ShelterService {
     shelter.verify();
   }
 
+  /**
+   * 보호소 정보 수정
+   * @param shelterId 수정할 보호소 아이디
+   * @param request 보호소 수정 요청
+   * @param shelterImage 보호소 이미지
+   * @param userId 보호소를 수정할 사용자 아이디
+   * @return 보호소 수정 응답
+   */
   @Transactional
   public ShelterUpdateResponse updateShelter(long shelterId, ShelterUpdateRequest request,
       MultipartFile shelterImage, long userId) {
@@ -87,46 +97,139 @@ public class ShelterService {
     return ShelterUpdateResponse.fromEntity(shelter);
   }
 
+  /**
+   * 보호소 삭제
+   * @param shelterId 삭제할 보호소 아이디
+   * @param userId 보호소를 삭제할 사용자 아이디
+   */
+  @Transactional
+  public void unregisterShelter(long shelterId, long userId) {
+    User user = findByUserIdOrThrow(userId);
+    Shelter shelter = findByShelterIdOrThrow(shelterId);
+
+    throwIfUserIsNotShelterUser(user, shelter);
+
+    user.unregisterShelter();
+
+    // TODO: 쿼리 최적화 (queryDSL 필요할 듯)
+    chatRoomRepository
+        .findAllByShelterId(shelterId)
+        .forEach(ChatRoom::leaveShelter);
+  }
+
+  /**
+   * 보호소를 등록한 사용자가 아니라면 예외를 발생한다.
+   * @param user 확인할 사용자
+   * @param shelter 보호소
+   */
   private void throwIfUserIsNotShelterUser(User user, Shelter shelter) {
     if (!Objects.equals(user.getId(), shelter.getUser().getId())) {
       throw new NoAuthorizedException();
     }
   }
 
+  /**
+   * 보호소가 승인되지 않은 상태면 예외를 발생한다.
+   * @param shelter 보호소
+   */
   private void throwIfShelterNotVerified(Shelter shelter) {
-    if (shelter != null && !shelter.isVerified()) {
+    if (shelter != null && !shelter.isDeleted() && !shelter.isVerified()) {
       throw new NotVerifiedShelterExistsException();
     }
   }
 
+  /**
+   * 사용자가 이미 승인된 보호소를 등록한 상태라면 예외를 발생한다.
+   * @param user 사용자
+   */
   private void throwIfUserAlreadyRegisterShelter(User user) {
-    if (user.getShelter() != null && user.getShelter().isVerified()) {
+    Shelter shelter = user.getShelter();
+    if (shelter != null && shelter.isVerified()) {
       throw new UserAlreadyRegisterShelterException();
     }
   }
 
-  private void throwIfUserHasNotAdminRole(User user) throws CustomException {
+  /**
+   * 사용자가 ADMIN 권한이 없으면 예외를 발생한다.
+   * @param user 사용자
+   */
+  private void throwIfUserHasNotAdminRole(User user) {
     // TODO: 권한 제어 설정 후 삭제 확인
     if (!user.getRole().contains(ADMIN)) {
-      throw new CustomException(FAILED);
+      throw new NoAuthorizedException();
     }
   }
 
+  /**
+   * 보호소가 이미 인증된 상태라면 예외를 발생한다.
+   *
+   * @param shelter 보호소
+   */
   private void throwIfShelterAlreadyVerified(Shelter shelter) {
     if (shelter.isVerified()) {
       throw new ShelterAlreadyVerifiedException(shelter.getId());
     }
   }
 
+  /**
+   * 사용자를 반환한다.
+   *
+   * @param userId 사용자 아이디
+   * @return 사용자
+   */
   private User findByUserIdOrThrow(long userId) {
     return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
   }
 
+  /**
+   * 삭제되지 않은 보호소를 반환한다.
+   *
+   * @param shelterId 보호소 아이디
+   * @return 보호소
+   */
   private Shelter findByShelterIdOrThrow(long shelterId) {
-    return shelterRepository.findById(shelterId)
+    Shelter shelter = shelterRepository.findById(shelterId)
         .orElseThrow(() -> new ShelterNotFoundException(shelterId));
+
+    if (shelter.isDeleted()) {
+      throw new ShelterNotFoundException(shelterId);
+    }
+
+    return shelter;
   }
 
+  /**
+   * 보호소를 등록하거나 복구한다.
+   *
+   * @param user         사용자
+   * @param request      보호소 등록 요청
+   * @param shelterImage 보호소 이미지
+   */
+  private void registerOrRestoreShelter(User user, ShelterRegisterRequest request,
+      S3Object shelterImage) {
+    Shelter shelter = user.getShelter();
+    if (shelter == null) {
+      shelter = Shelter.builder()
+          .name(request.getName())
+          .description(request.getDescription())
+          .tel(request.getTel())
+          .address(request.getAddress())
+          .latitude(request.getLatitude())
+          .longitude(request.getLongitude())
+          .shelterImgUrl(shelterImage.getUrl())
+          .verified(false)
+          .user(user)
+          .build();
+    }
+    user.registerShelter(shelter);
+  }
+
+  /**
+   * 보호소 이미지 업로드
+   *
+   * @param shelterImage 이미지
+   * @return 업로드된 객체
+   */
   private S3Object uploadShelterImage(MultipartFile shelterImage) {
     if (shelterImage != null && !shelterImage.isEmpty()) {
       return S3Object.from(s3Service.uploadOneFile(shelterImage));
@@ -134,6 +237,11 @@ public class ShelterService {
     return null;
   }
 
+  /**
+   * 보호소에 등록된 이미지가 있으면 삭제한다
+   *
+   * @param oldShelterImage 이미지
+   */
   private void deleteOldShelterImageIfExists(S3Object oldShelterImage) {
     if (oldShelterImage == null) {
       return;

--- a/src/main/java/homes/banzzokee/domain/user/entity/User.java
+++ b/src/main/java/homes/banzzokee/domain/user/entity/User.java
@@ -119,28 +119,52 @@ public class User extends BaseEntity {
     }
   }
 
+  /**
+   * @return 사용자 탈퇴 여부
+   */
   public boolean isWithdrawn() {
     return this.deletedAt != null;
   }
 
+  /**
+   * @return 사용자 프로필 이미지 경로
+   */
   public String getProfileImageUrl() {
     return this.getProfileImage() != null ? this.getProfileImage().getUrl() : null;
   }
 
+  /**
+   * 사용자 탈퇴
+   */
   public void withdraw() {
     if (this.deletedAt == null) {
       this.deletedAt = LocalDateTime.now();
     }
   }
 
+  /**
+   * 사용자 패스워드 변경
+   *
+   * @param newPassword 새로운 패스워드
+   */
   public void changePassword(String newPassword) {
     this.password = newPassword;
   }
 
+  /**
+   * @return SHELTER 권한 소유 확인
+   */
   public boolean hasShelter() {
     return this.role.contains(SHELTER);
   }
 
+  /**
+   * 사용자 프로필 수정
+   *
+   * @param nickname     닉네임
+   * @param introduce    자기소개
+   * @param profileImage 프로필 이미지
+   */
   public void updateProfile(String nickname, String introduce,
       S3Object profileImage) {
     this.nickname = nickname;
@@ -150,13 +174,33 @@ public class User extends BaseEntity {
     }
   }
 
+  /**
+   * 보호소 등록
+   * @param shelter 보호소
+   */
   public void registerShelter(Shelter shelter) {
     if (this.shelter == null) {
       this.shelter = shelter;
     }
+
+    if (this.shelter.isDeleted()) {
+      this.shelter.restore();
+    }
   }
 
+  /**
+   * 권한 추가
+   * @param roles 권한 목록
+   */
   public void addRoles(Role... roles) {
     this.role.addAll(Arrays.asList(roles));
+  }
+
+  /**
+   * 보호소 삭제
+   */
+  public void unregisterShelter() {
+    this.shelter.delete();
+    this.role.remove(SHELTER);
   }
 }

--- a/src/test/java/homes/banzzokee/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/shelter/controller/ShelterControllerTest.java
@@ -175,4 +175,26 @@ class ShelterControllerTest {
     assertEquals(mockFile.getOriginalFilename(),
         shelterImageCaptor.getValue().getOriginalFilename());
   }
+
+  @Test
+  @DisplayName("[보호소 삭제] - 성공 검증")
+  void unregisterShelter_when_validInput_then_success() throws Exception {
+    // given
+    // when
+    ResultActions resultActions = MockMvcUtil.performDelete(mockMvc, "/api/shelters/1?userId=1");
+
+    // then
+    resultActions.andExpect(status().isOk());
+
+    ArgumentCaptor<Long> shelterIdCaptor
+        = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Long> userIdCaptor
+        = ArgumentCaptor.forClass(Long.class);
+
+    verify(shelterService)
+        .unregisterShelter(shelterIdCaptor.capture(), userIdCaptor.capture());
+
+    assertEquals(1L, shelterIdCaptor.getValue());
+    assertEquals(1L, userIdCaptor.getValue());
+  }
 }

--- a/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
@@ -30,20 +30,17 @@ import homes.banzzokee.domain.type.S3Object;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.entity.User;
 import homes.banzzokee.domain.user.exception.UserNotFoundException;
-import homes.banzzokee.global.error.exception.CustomException;
 import homes.banzzokee.global.error.exception.NoAuthorizedException;
 import homes.banzzokee.global.util.MockDataUtil;
 import homes.banzzokee.infra.fileupload.dto.ImageDto;
 import homes.banzzokee.infra.fileupload.service.FileUploadService;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,97 +68,138 @@ class ShelterServiceTest {
   @InjectMocks
   private ShelterService shelterService;
 
-  private final User mockUser = mock(User.class);
-  private final User mockShelterUser = mock(User.class);
-  private final Shelter mockShelter = mock(Shelter.class);
   private final MultipartFile mockFile = MockDataUtil.createMockMultipartFile(
       "shelterImg",
       "src/test/resources/images/banzzokee.png");
-  private final Set<Role> adminRole = new HashSet<>(Collections.singleton(ADMIN));
-  private final ShelterRegisterRequest mockShelterRegisterRequest = mock(
-      ShelterRegisterRequest.class);
-  private final ShelterUpdateRequest mockShelterUpdateRequest
-      = mock(ShelterUpdateRequest.class);
+  private static final ShelterRegisterRequest shelterRegisterRequest
+      = ShelterRegisterRequest.builder()
+      .name("보호소")
+      .description("설명")
+      .tel("02-1234-5678")
+      .address("주소")
+      .latitude(24.0)
+      .longitude(37.0)
+      .build();
+  private static final ShelterUpdateRequest shelterUpdateRequest
+      = ShelterUpdateRequest.builder()
+      .name("name")
+      .description("description")
+      .tel("02-1234-5678")
+      .address("address")
+      .latitude(1.0)
+      .longitude(2.0)
+      .build();
+
+  private static final ImageDto image = ImageDto.builder()
+      .url("url")
+      .filename("filename")
+      .build();
 
   ShelterServiceTest() throws IOException {
   }
-
-  @BeforeEach
-  public void setup() {
-    given(mockUser.getId()).willReturn(1L);
-
-    given(mockShelterUser.getId()).willReturn(2L);
-    given(mockShelterUser.getShelter()).willReturn(mockShelter);
-
-    given(mockShelter.getId()).willReturn(1L);
-    given(mockShelter.getUser()).willReturn(mockShelterUser);
-  }
-
 
   @Test
   @DisplayName("[보호소 등록] - 사용자를 못찾으면 UserNotFoundException 발생")
   void registerShelter_when_userNotExists_then_throwUserNotFoundException() {
     // given
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.empty());
+    given(userRepository.findById(anyLong())).willReturn(Optional.empty());
 
-    // when
-    // then
+    // when & then
     assertThrows(UserNotFoundException.class,
-        () -> shelterService.registerShelter(mockShelterRegisterRequest, mockFile,
-            mockUser.getId()));
+        () -> shelterService.registerShelter(shelterRegisterRequest,
+            mockFile,
+            anyLong()));
   }
 
   @Test
   @DisplayName("[보호소 등록] - 승인되지 않은 보호소가 존재하는 경우 NotVerifiedShelterExistsException 발생")
   void registerShelter_when_ShelterIsNotVerified_then_throwNotVerifiedShelterExistsException() {
     // given
-    Shelter mockShelter = mock(Shelter.class);
-    given(mockShelter.isVerified()).willReturn(false);
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.isVerified()).willReturn(false);
 
-    given(mockUser.getShelter()).willReturn(mockShelter);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
+    User user = mock(User.class);
+    given(user.getShelter()).willReturn(shelter);
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
 
-    // when
-    // then
+    // when & then
     assertThrows(NotVerifiedShelterExistsException.class,
-        () -> shelterService.registerShelter(mockShelterRegisterRequest,
+        () -> shelterService.registerShelter(shelterRegisterRequest,
             mockFile,
-            mockUser.getId()));
+            anyLong()));
   }
 
   @Test
   @DisplayName("[보호소 등록] - 등록된 보호소가 있으면 UserAlreadyRegisterShelterException 발생")
   void registerShelter_when_hasShelter_then_throwUserAlreadyRegisterShelterException() {
     // given
-    Shelter mockShelter = mock(Shelter.class);
-    given(mockShelter.isVerified()).willReturn(true);
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.isVerified()).willReturn(true);
 
-    given(mockUser.getShelter()).willReturn(mockShelter);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
+    User user = mock(User.class);
+    given(user.getShelter()).willReturn(shelter);
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
 
-    // when
-    // then
+    // when & then
     assertThrows(UserAlreadyRegisterShelterException.class,
-        () -> shelterService.registerShelter(mockShelterRegisterRequest, mockFile,
-            mockUser.getId()));
+        () -> shelterService.registerShelter(shelterRegisterRequest,
+            mockFile,
+            anyLong()));
   }
 
   @Test
-  @DisplayName("[보호소 등록] - 성공 검증")
-  void registerShelter_success_verify() {
+  @DisplayName("[보호소 등록] - 성공 검증, 새로운 보호소 등록")
+  void registerShelter_success_verify_when_registerNew() {
     // given
-    given(mockUser.hasShelter()).willReturn(false);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-
-    ImageDto image = ImageDto.builder().url("url").filename("filename").build();
+    User user = mock(User.class);
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
     given(s3Service.uploadOneFile(any(MultipartFile.class))).willReturn(image);
 
     // when
-    ShelterRegisterRequest request = ShelterRegisterRequest.builder().name("보호소")
-        .description("설명").tel("02-1234-5678").address("주소").latitude(24.0)
-        .longitude(37.0).build();
+    shelterService.registerShelter(shelterRegisterRequest, mockFile, anyLong());
 
-    shelterService.registerShelter(request, mockFile, mockUser.getId());
+    // then
+    // 이미지 업로드 검증
+    ArgumentCaptor<MultipartFile> shelterImgCaptor
+        = ArgumentCaptor.forClass(MultipartFile.class);
+    verify(s3Service).uploadOneFile(shelterImgCaptor.capture());
+    assertEquals(mockFile.getSize(), shelterImgCaptor.getValue().getSize());
+    assertEquals(mockFile.getName(), shelterImgCaptor.getValue().getName());
+
+    // 보호소 저장 검증
+    ArgumentCaptor<Shelter> shelterCaptor = ArgumentCaptor.forClass(Shelter.class);
+    verify(user).registerShelter(shelterCaptor.capture());
+    Shelter shelter = shelterCaptor.getValue();
+    assertEquals(shelterRegisterRequest.getName(), shelter.getName());
+    assertEquals(shelterRegisterRequest.getDescription(), shelter.getDescription());
+    assertEquals(shelterRegisterRequest.getTel(), shelter.getTel());
+    assertEquals(shelterRegisterRequest.getAddress(), shelter.getAddress());
+    assertEquals(shelterRegisterRequest.getLatitude(), shelter.getLatitude());
+    assertEquals(shelterRegisterRequest.getLongitude(), shelter.getLongitude());
+    assertEquals(image.getUrl(), shelter.getShelterImageUrl());
+    assertFalse(shelter.isVerified());
+  }
+
+  @Test
+  @DisplayName("[보호소 등록] - 성공 검증, 삭제된 보호소 복원")
+  void registerShelter_success_verify_when_restoreShelter() {
+    // given
+    Shelter shelter = spy(Shelter.builder()
+        .user(User.builder().build())
+        .build());
+    given(shelter.getId()).willReturn(1L);
+    given(shelter.isDeleted()).willReturn(true);
+
+    User user = spy(User.builder()
+        .shelter(shelter)
+        .build());
+    given(user.getId()).willReturn(1L);
+    given(userRepository.findById(shelter.getId())).willReturn(Optional.of(user));
+
+    given(s3Service.uploadOneFile(any(MultipartFile.class))).willReturn(image);
+
+    // when
+    shelterService.registerShelter(shelterRegisterRequest, mockFile, user.getId());
 
     // then
     // 이미지 업로드 검증
@@ -170,126 +208,115 @@ class ShelterServiceTest {
     verify(s3Service).uploadOneFile(shelterImgCaptor.capture());
     assertEquals(mockFile.getSize(), shelterImgCaptor.getValue().getSize());
 
-    // 보호소 저장 검증
-    ArgumentCaptor<Shelter> shelterCaptor = ArgumentCaptor.forClass(Shelter.class);
-    verify(mockUser).registerShelter(shelterCaptor.capture());
-    Shelter shelter = shelterCaptor.getValue();
-    assertEquals(request.getName(), shelter.getName());
-    assertEquals(request.getDescription(), shelter.getDescription());
-    assertEquals(request.getTel(), shelter.getTel());
-    assertEquals(request.getAddress(), shelter.getAddress());
-    assertEquals(request.getLatitude(), shelter.getLatitude());
-    assertEquals(request.getLongitude(), shelter.getLongitude());
-    assertEquals(image.getUrl(), shelter.getShelterImageUrl());
+    // 보호소 복구 검증
+    verify(user).registerShelter(shelter);
+    verify(shelter).restore();
     assertFalse(shelter.isVerified());
+    assertNull(shelter.getDeletedAt());
   }
 
   @Test
-  @DisplayName("[보호소 승인] - 호출자가 ADMIN 권한이 없으면 CustomException 발생")
-  void verifyShelter_when_userHasNotAdminRole_then_throwCustomException() {
+  @DisplayName("[보호소 승인] - 호출자가 ADMIN 권한이 없으면 NoAuthorizedException 발생")
+  void verifyShelter_when_userHasNotAdminRole_then_throwNoAuthorizedException() {
     // given
-    given(mockUser.getRole()).willReturn(Collections.emptySet());
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
+    User user = mock(User.class);
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
 
-    // when
-    // then
-    assertThrows(CustomException.class,
-        () -> shelterService.verifyShelter(1L, mockUser.getId()));
+    // when & then
+    assertThrows(NoAuthorizedException.class,
+        () -> shelterService.verifyShelter(1L, anyLong()));
   }
 
   @Test
   @DisplayName("[보호소 승인] - 보호소를 찾을 수 없으면 ShelterNotFoundException 발생")
   void verifyShelter_when_shelterNotExists_then_throwShelterNotFoundException() {
     // given
-    given(mockUser.getRole()).willReturn(adminRole);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId())).willReturn(Optional.empty());
+    User user = mock(User.class);
+    given(user.getRole()).willReturn(getRoles(ADMIN));
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+    given(shelterRepository.findById(1L)).willReturn(Optional.empty());
 
-    // when
-    // then
+    // when & then
     assertThrows(ShelterNotFoundException.class,
-        () -> shelterService.verifyShelter(mockShelter.getId(), mockUser.getId()));
+        () -> shelterService.verifyShelter(1L, anyLong()));
   }
 
   @Test
   @DisplayName("[보호소 승인] - 승인된 보호소면 ShelterAlreadyVerifiedException 발생")
   void verifyShelter_when_shelterVerified_then_throwShelterAlreadyVerifiedException() {
     // given
-    given(mockUser.getRole()).willReturn(adminRole);
-    given(mockShelter.isVerified()).willReturn(true);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(mockShelter));
+    User user = mock(User.class);
+    given(user.getRole()).willReturn(getRoles(ADMIN));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
-    // when
-    // then
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.isVerified()).willReturn(true);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+
+    // when & then
     assertThrows(ShelterAlreadyVerifiedException.class,
-        () -> shelterService.verifyShelter(mockShelter.getId(), mockUser.getId()));
+        () -> shelterService.verifyShelter(shelter.getId(), user.getId()));
   }
 
   @Test
   @DisplayName("[보호소 승인] - 성공 검증")
   void verifyShelter_success_verify() {
     // given
-    given(mockUser.getRole()).willReturn(adminRole);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-
-    Set<Role> roles = new HashSet<>();
-    roles.add(USER);
-
     User user = spy(User.builder()
-        .role(roles)
+        .role(getRoles(ADMIN))
         .build());
-    Shelter shelter = spy(Shelter.builder()
-        .user(user)
-        .build());
+    given(user.getId()).willReturn(1L);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(shelter));
+    Shelter shelter = spy(Shelter.builder().user(user).build());
+    given(shelter.getId()).willReturn(1L);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
-    shelterService.verifyShelter(mockShelter.getId(), mockUser.getId());
+    shelterService.verifyShelter(shelter.getId(), user.getId());
 
     // then
     verify(shelter).verify();
     assertTrue(shelter.isVerified());
     assertTrue(user.getRole().contains(SHELTER));
-    assertTrue(user.getRole().contains(USER));
   }
 
   @Test
   @DisplayName("[보호소 수정] - 보호소를 찾을 수 없으면 ShelterNotFoundException 발생")
   void updateShelter_when_shelterNotExists_then_throwShelterNotFoundException() {
     // given
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.empty());
+    User user = mock(User.class);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
-    // when
-    // then
+    Shelter shelter = mock(Shelter.class);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.empty());
+
+    // when & then
     assertThrows(ShelterNotFoundException.class,
-        () -> shelterService.updateShelter(mockShelter.getId(),
-            mockShelterUpdateRequest,
+        () -> shelterService.updateShelter(shelter.getId(),
+            shelterUpdateRequest,
             mockFile,
-            mockUser.getId()));
+            user.getId()));
   }
 
   @Test
   @DisplayName("[보호소 수정] - 사용자가 보호소를 등록한 사용자가 아니면 NoAuthorizedException 발생")
   void updateShelter_when_userIsNotShelterUser_then_throwNoAuthorizedException() {
     // given
-    given(mockShelter.getUser()).willReturn(mock(User.class));
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(mockShelter));
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.getUser()).willReturn(mock(User.class));
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
 
-    // when
-    // then
+    User user = mock(User.class);
+    given(user.getId()).willReturn(1L);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+    // when & then
     assertThrows(NoAuthorizedException.class,
-        () -> shelterService.updateShelter(mockShelter.getId(),
-            mockShelterUpdateRequest,
+        () -> shelterService.updateShelter(shelter.getId(),
+            shelterUpdateRequest,
             mockFile,
-            mockUser.getId()));
+            user.getId()));
   }
 
   @Test
@@ -297,17 +324,20 @@ class ShelterServiceTest {
   void updateShelter_when_oldShelterImageNotNull_then_deleteOldShelterImage() {
     // given
     S3Object oldShelterImage = new S3Object("oldShelterImage.png");
-    given(mockShelter.getUser()).willReturn(mockUser);
-    given(mockShelter.getShelterImage()).willReturn(oldShelterImage);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(mockShelter));
+
+    User user = mock(User.class);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.getUser()).willReturn(user);
+    given(shelter.getShelterImage()).willReturn(oldShelterImage);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
-    shelterService.updateShelter(mockShelter.getId(),
-        mockShelterUpdateRequest,
+    shelterService.updateShelter(shelter.getId(),
+        shelterUpdateRequest,
         mockFile,
-        mockUser.getId());
+        user.getId());
 
     // then
     verify(s3Service).deleteFile(oldShelterImage.getFileName());
@@ -317,16 +347,18 @@ class ShelterServiceTest {
   @DisplayName("[보호소 수정] - 성공 검증, 이전 이미지가 null이 아닌 경우 삭제한다")
   void updateShelter_when_shelterImageNotNull_then_uploadShelterImage() {
     // given
-    given(mockShelter.getUser()).willReturn(mockUser);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(mockShelter));
+    User user = mock(User.class);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.getUser()).willReturn(user);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
-    shelterService.updateShelter(mockShelter.getId(),
-        mockShelterUpdateRequest,
+    shelterService.updateShelter(shelter.getId(),
+        shelterUpdateRequest,
         mockFile,
-        mockUser.getId());
+        user.getId());
 
     // then
     verify(s3Service).uploadOneFile(mockFile);
@@ -336,58 +368,45 @@ class ShelterServiceTest {
   @DisplayName("[보호소 수정] - 성공 검증")
   void updateShelter_when_success_then_verify() {
     // given
-    Shelter shelter = spy(Shelter.builder()
-        .user(mockUser)
-        .build());
+    User user = mock(User.class);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
-    given(mockShelter.getUser()).willReturn(mockUser);
-    given(userRepository.findById(mockUser.getId())).willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.of(shelter));
-    given(s3Service.uploadOneFile(mockFile))
-        .willReturn(ImageDto.builder()
-            .filename("filename")
-            .url("url")
-            .build());
+    Shelter shelter = spy(Shelter.builder()
+        .user(user)
+        .build());
+    given(shelter.getId()).willReturn(1L);
+    given(shelter.getUser()).willReturn(user);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+
+    given(s3Service.uploadOneFile(mockFile)).willReturn(image);
 
     // when
-    ShelterUpdateRequest request = ShelterUpdateRequest.builder()
-        .name("name")
-        .description("description")
-        .tel("02-1234-5678")
-        .address("address")
-        .latitude(1.0)
-        .longitude(2.0)
-        .build();
-
-    shelterService.updateShelter(mockShelter.getId(),
-        request,
+    shelterService.updateShelter(shelter.getId(),
+        shelterUpdateRequest,
         mockFile,
-        mockUser.getId());
+        user.getId());
 
     // then
-    assertEquals(request.getName(), shelter.getName());
-    assertEquals(request.getDescription(), shelter.getDescription());
-    assertEquals(request.getTel(), shelter.getTel());
-    assertEquals(request.getAddress(), shelter.getAddress());
-    assertEquals(request.getLatitude(), shelter.getLatitude());
-    assertEquals(request.getLongitude(), shelter.getLongitude());
-    assertEquals("url", shelter.getShelterImageUrl());
+    assertEquals(shelterUpdateRequest.getName(), shelter.getName());
+    assertEquals(shelterUpdateRequest.getDescription(), shelter.getDescription());
+    assertEquals(shelterUpdateRequest.getTel(), shelter.getTel());
+    assertEquals(shelterUpdateRequest.getAddress(), shelter.getAddress());
+    assertEquals(shelterUpdateRequest.getLatitude(), shelter.getLatitude());
+    assertEquals(shelterUpdateRequest.getLongitude(), shelter.getLongitude());
+    assertEquals(image.getUrl(), shelter.getShelterImageUrl());
   }
 
   @Test
   @DisplayName("[보호소 삭제] - 보호소를 찾을 수 없으면 ShelterNotFoundException 발생")
   void unregisterShelter_when_shelterNotExists_then_throwShelterNotFoundException() {
     // given
-    given(userRepository.findById(mockUser.getId()))
-        .willReturn(Optional.of(mockUser));
-    given(shelterRepository.findById(mockShelter.getId()))
-        .willReturn(Optional.empty());
+    User user = mock(User.class);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(shelterRepository.findById(anyLong())).willReturn(Optional.empty());
 
-    // when
-    // then
+    // when & then
     assertThrows(ShelterNotFoundException.class,
-        () -> shelterService.unregisterShelter(mockShelter.getId(), mockUser.getId()));
+        () -> shelterService.unregisterShelter(1L, user.getId()));
   }
 
   @Test
@@ -396,20 +415,16 @@ class ShelterServiceTest {
     // given
     User user1 = mock(User.class);
     given(user1.getId()).willReturn(1L);
+    given(userRepository.findById(user1.getId())).willReturn(Optional.of(user1));
 
     User user2 = mock(User.class);
     given(user2.getId()).willReturn(2L);
 
     Shelter shelter = mock(Shelter.class);
     given(shelter.getUser()).willReturn(user2);
+    given(shelterRepository.findById(anyLong())).willReturn(Optional.of(shelter));
 
-    given(userRepository.findById(anyLong()))
-        .willReturn(Optional.of(user1));
-    given(shelterRepository.findById(anyLong()))
-        .willReturn(Optional.of(shelter));
-
-    // when
-    // then
+    // when & then
     assertThrows(NoAuthorizedException.class,
         () -> shelterService.unregisterShelter(shelter.getId(), user1.getId()));
   }
@@ -422,23 +437,18 @@ class ShelterServiceTest {
         .user(User.builder().build())
         .build());
     given(shelter.getId()).willReturn(1L);
+    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
 
-    Set<Role> roles = new HashSet<>(Arrays.asList(USER, SHELTER));
     User user = spy(User.builder()
-        .role(roles)
+        .role(getRoles(USER, SHELTER))
         .shelter(shelter)
         .build());
     given(user.getId()).willReturn(1L);
     given(shelter.getUser()).willReturn(user);
-
-    given(userRepository.findById(shelter.getId()))
-        .willReturn(Optional.of(user));
-    given(shelterRepository.findById(user.getId()))
-        .willReturn(Optional.of(shelter));
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
     List<ChatRoom> chatRooms = getMockChatRooms(shelter);
-    given(chatRoomRepository.findAllByShelterId(shelter.getId()))
-        .willReturn(chatRooms);
+    given(chatRoomRepository.findAllByShelterId(shelter.getId())).willReturn(chatRooms);
 
     // when
     shelterService.unregisterShelter(shelter.getId(), user.getId());
@@ -451,7 +461,7 @@ class ShelterServiceTest {
     assertTrue(shelter.isDeleted());
     assertFalse(shelter.isVerified());
 
-    for (ChatRoom chatRoom: chatRooms) {
+    for (ChatRoom chatRoom : chatRooms) {
       verify(chatRoom).leaveShelter();
       assertNull(chatRoom.getShelter());
     }
@@ -463,5 +473,9 @@ class ShelterServiceTest {
             .shelter(shelter)
             .build()))
         .toList();
+  }
+
+  private Set<Role> getRoles(Role... roles) {
+    return Arrays.stream(roles).collect(Collectors.toSet());
   }
 }

--- a/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
@@ -242,6 +242,23 @@ class ShelterServiceTest {
   }
 
   @Test
+  @DisplayName("[보호소 승인] - 삭제된 보호소이면 ShelterNotFoundException 발생")
+  void verifyShelter_when_shelterIsDeleted_then_throwShelterNotFoundException() {
+    // given
+    User user = mock(User.class);
+    given(user.getRole()).willReturn(getRoles(ADMIN));
+    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+    Shelter shelter = mock(Shelter.class);
+    given(shelter.isDeleted()).willReturn(true);
+    given(shelterRepository.findById(1L)).willReturn(Optional.of(shelter));
+
+    // when & then
+    assertThrows(ShelterNotFoundException.class,
+        () -> shelterService.verifyShelter(1L, user.getId()));
+  }
+
+  @Test
   @DisplayName("[보호소 승인] - 승인된 보호소면 ShelterAlreadyVerifiedException 발생")
   void verifyShelter_when_shelterVerified_then_throwShelterAlreadyVerifiedException() {
     // given

--- a/src/test/java/homes/banzzokee/global/util/MockMvcUtil.java
+++ b/src/test/java/homes/banzzokee/global/util/MockMvcUtil.java
@@ -1,6 +1,7 @@
 package homes.banzzokee.global.util;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -38,5 +39,10 @@ public class MockMvcUtil {
             get(url)
                 .contentType(APPLICATION_JSON))
         .andDo(print());
+  }
+
+  public static ResultActions performDelete(MockMvc mockMvc, String url)
+      throws Exception {
+    return mockMvc.perform(delete(url)).andDo(print());
   }
 }


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
보호소 삭제 기능 구현
- 보호소를 찾을 수 없거나, 삭제된 보호소면 예외 발생 (`ShelterNotFoundException`)
- 보호소를 등록한 사용자가 아니면 예외 발생 (`NoAuthorizedException`)

로직
1. 사용자의 보호소 관계를 지우지 않고 보호소 정보만 업데이트
 - `verified = false;` 
 - `deletedAt = LocalDateTime.now();`
2. 사용자의 `SHELTER` 권한 삭제
3. 보호소가 참여된 채팅 룸에서 보호소 null 업데이트
 - `shelter = null`

보호소 재등록 로직 추가
- 보호소 삭제 시 사용자와 관계를 유지하여 삭제된 상태에서 보호소를 다시 등록 시 기존 보호소 필드만 업데이트
 - `verified = false;` 다시 승인이 필요
 - `deletedAt = LocalDateTime.now();`

**보호소가 삭제되면 프로필 조회 시 보호소 정보를 가져오지 않습니다.**

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
보호소 삭제 API가 필요합니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->
해결한 이슈: #61 

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
<img width="888" alt="image" src="https://github.com/banzzokee/banzzokee-back/assets/43163409/3350df88-904a-42c1-917f-4a544bbb9ec3">


## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
