### PR TITLE
feature: register fcm token

### DIFF
--- a/src/main/java/homes/banzzokee/domain/notification/controller/NotificationController.java
+++ b/src/main/java/homes/banzzokee/domain/notification/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package homes.banzzokee.domain.notification.controller;
+
+import homes.banzzokee.domain.notification.dto.FcmTokenRegisterRequest;
+import homes.banzzokee.domain.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @PutMapping("tokens")
+  public void registerFcmToken(@Valid @RequestBody FcmTokenRegisterRequest request,
+      @RequestHeader("User-Agent") String userAgent, @RequestParam long userId) {
+    // TODO: userId -> @AuthenticationPrincipal 바꾸기
+    notificationService.registerFcmToken(request, userAgent, userId);
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/notification/dao/FcmTokenRepository.java
+++ b/src/main/java/homes/banzzokee/domain/notification/dao/FcmTokenRepository.java
@@ -1,0 +1,12 @@
+package homes.banzzokee.domain.notification.dao;
+
+import homes.banzzokee.domain.notification.entity.FcmToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+  Optional<FcmToken> findByToken(String token);
+}

--- a/src/main/java/homes/banzzokee/domain/notification/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/homes/banzzokee/domain/notification/dto/FcmTokenRegisterRequest.java
@@ -1,0 +1,21 @@
+package homes.banzzokee.domain.notification.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * FCM 토큰 등록 요청
+ */
+@Getter
+@Builder
+@RequiredArgsConstructor(onConstructor_ = @JsonCreator, access = PRIVATE)
+public class FcmTokenRegisterRequest {
+
+  @NotBlank
+  private final String token;
+}

--- a/src/main/java/homes/banzzokee/domain/notification/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/homes/banzzokee/domain/notification/dto/FcmTokenRegisterRequest.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PRIVATE;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Builder
 @RequiredArgsConstructor(onConstructor_ = @JsonCreator, access = PRIVATE)
+@EqualsAndHashCode
 public class FcmTokenRegisterRequest {
 
   @NotBlank

--- a/src/main/java/homes/banzzokee/domain/notification/entity/FcmToken.java
+++ b/src/main/java/homes/banzzokee/domain/notification/entity/FcmToken.java
@@ -1,0 +1,67 @@
+package homes.banzzokee.domain.notification.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import homes.banzzokee.domain.common.entity.BaseEntity;
+import homes.banzzokee.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED, force = true)
+public class FcmToken extends BaseEntity {
+
+  /**
+   * FCM 토큰 아이디
+   */
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  /**
+   * FCM 토큰
+   */
+  @Column(unique = true)
+  private final String token;
+
+  /**
+   * FCM 토큰을 등록한 디바이스의 User-Agent
+   */
+  private final String userAgent;
+
+  /**
+   * FCM 토큰 소유자
+   */
+  @ManyToOne(fetch = LAZY)
+  private final User user;
+
+  /**
+   * FCM 토큰의 마지막 사용 일시(사용 갱신)
+   */
+  private LocalDateTime lastUsedAt;
+
+  @Builder
+  protected FcmToken(String token, String userAgent, User user) {
+    this.token = token;
+    this.userAgent = userAgent;
+    this.user = user;
+    this.lastUsedAt = LocalDateTime.now();
+  }
+
+  /**
+   * FCM 토큰의 사용 일시를 갱신한다.
+   */
+  public void refresh() {
+    lastUsedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/homes/banzzokee/domain/notification/service/NotificationService.java
+++ b/src/main/java/homes/banzzokee/domain/notification/service/NotificationService.java
@@ -6,6 +6,8 @@ import homes.banzzokee.domain.notification.entity.FcmToken;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.entity.User;
 import homes.banzzokee.domain.user.exception.UserNotFoundException;
+import homes.banzzokee.global.error.exception.NoAuthorizedException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,13 @@ public class NotificationService {
   private final FcmTokenRepository fcmTokenRepository;
   private final UserRepository userRepository;
 
+  /**
+   * FCM 토큰 등록
+   *
+   * @param request   토큰 등록 요청
+   * @param userAgent User-Agent
+   * @param userId    토큰을 등록할 사용자 아이디
+   */
   @Transactional
   public void registerFcmToken(FcmTokenRegisterRequest request, String userAgent,
       long userId) {
@@ -24,7 +33,10 @@ public class NotificationService {
 
     fcmTokenRepository.findByToken(request.getToken())
         .ifPresentOrElse(
-            FcmToken::refresh,
+            (token) -> {
+              throwIfUserIsNotTokenUser(user, token);
+              token.refresh();
+            },
             () -> fcmTokenRepository.save(FcmToken.builder()
                 .token(request.getToken())
                 .userAgent(userAgent)
@@ -32,7 +44,25 @@ public class NotificationService {
                 .build()));
   }
 
+  /**
+   * 사용자를 반환한다.
+   *
+   * @param userId 사용자 아이디
+   * @return 사용자
+   */
   private User findUserByIdOrThrow(long userId) {
     return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+  }
+
+  /**
+   * 토큰을 등록한 사용자가 아니라면 예외를 발생한다.
+   *
+   * @param user  확인할 사용자
+   * @param token 토큰
+   */
+  private void throwIfUserIsNotTokenUser(User user, FcmToken token) {
+    if (!Objects.equals(user.getId(), token.getUser().getId())) {
+      throw new NoAuthorizedException();
+    }
   }
 }

--- a/src/main/java/homes/banzzokee/domain/notification/service/NotificationService.java
+++ b/src/main/java/homes/banzzokee/domain/notification/service/NotificationService.java
@@ -1,0 +1,38 @@
+package homes.banzzokee.domain.notification.service;
+
+import homes.banzzokee.domain.notification.dao.FcmTokenRepository;
+import homes.banzzokee.domain.notification.dto.FcmTokenRegisterRequest;
+import homes.banzzokee.domain.notification.entity.FcmToken;
+import homes.banzzokee.domain.user.dao.UserRepository;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.domain.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final FcmTokenRepository fcmTokenRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void registerFcmToken(FcmTokenRegisterRequest request, String userAgent,
+      long userId) {
+    User user = findUserByIdOrThrow(userId);
+
+    fcmTokenRepository.findByToken(request.getToken())
+        .ifPresentOrElse(
+            FcmToken::refresh,
+            () -> fcmTokenRepository.save(FcmToken.builder()
+                .token(request.getToken())
+                .userAgent(userAgent)
+                .user(user)
+                .build()));
+  }
+
+  private User findUserByIdOrThrow(long userId) {
+    return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+  }
+}

--- a/src/test/java/homes/banzzokee/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,46 @@
+package homes.banzzokee.domain.notification.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import homes.banzzokee.domain.notification.dto.FcmTokenRegisterRequest;
+import homes.banzzokee.domain.notification.service.NotificationService;
+import homes.banzzokee.global.util.MockMvcUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(value = NotificationController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class NotificationControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private NotificationService notificationService;
+
+  @Test
+  @DisplayName("[토큰 등록] - 성공 검증")
+  void registerFcmToken_when_validInput_then_success() throws Exception {
+    // given
+    FcmTokenRegisterRequest request = FcmTokenRegisterRequest.builder()
+        .token("token")
+        .build();
+
+    // when
+    ResultActions resultActions = MockMvcUtil.performPut(mockMvc,
+        "/api/notifications/tokens?userId=1", request);
+
+    // then
+    resultActions.andExpect(status().isOk());
+    verify(notificationService).registerFcmToken(eq(request),
+        eq("spring boot unit test"),
+        eq(1L));
+  }
+}

--- a/src/test/java/homes/banzzokee/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,113 @@
+package homes.banzzokee.domain.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import homes.banzzokee.domain.notification.dao.FcmTokenRepository;
+import homes.banzzokee.domain.notification.dto.FcmTokenRegisterRequest;
+import homes.banzzokee.domain.notification.entity.FcmToken;
+import homes.banzzokee.domain.user.dao.UserRepository;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.domain.user.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  @Mock
+  private FcmTokenRepository fcmTokenRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  private final static FcmTokenRegisterRequest TOKEN_REGISTER_REQUEST
+      = FcmTokenRegisterRequest.builder()
+      .token("token")
+      .build();
+
+  @Test
+  @DisplayName("[토큰 등록] - 사용자를 못찾으면 UserNotFoundException 발생")
+  void registerFcmToken_when_userNotExists_then_throwUserNotFoundException() {
+    // given
+    given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(UserNotFoundException.class,
+        () -> notificationService.registerFcmToken(TOKEN_REGISTER_REQUEST,
+            "userAgent",
+            1L));
+  }
+
+  @Test
+  @DisplayName("[토큰 등록] - 토큰이 존재하면 refresh() 호출 검증")
+  void registerFcmToken_when_tokenExists_then_refreshToken() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+
+    User user = mock(User.class);
+    given(user.getId()).willReturn(1L);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+    FcmToken token = spy(FcmToken.builder()
+        .token(TOKEN_REGISTER_REQUEST.getToken())
+        .userAgent("userAgent")
+        .user(user)
+        .build());
+    given(fcmTokenRepository.findByToken(token.getToken())).willReturn(
+        Optional.of(token));
+
+    // when
+    notificationService.registerFcmToken(TOKEN_REGISTER_REQUEST,
+        "userAgent",
+        1L);
+
+    // then
+    verify(token).refresh();
+    assertTrue(token.getLastUsedAt().isAfter(now));
+  }
+
+  @Test
+  @DisplayName("[토큰 등록] - 토큰이 없으면 새로 추가")
+  void registerFcmToken_when_tokenNotExists_then_saveToken() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+
+    User user = mock(User.class);
+    given(user.getId()).willReturn(1L);
+    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(fcmTokenRepository.findByToken(anyString())).willReturn(Optional.empty());
+
+    // when
+    notificationService.registerFcmToken(TOKEN_REGISTER_REQUEST,
+        "userAgent",
+        1L);
+
+    // then
+    ArgumentCaptor<FcmToken> tokenCaptor = ArgumentCaptor.forClass(FcmToken.class);
+    verify(fcmTokenRepository).save(tokenCaptor.capture());
+
+    FcmToken value = tokenCaptor.getValue();
+    assertEquals(TOKEN_REGISTER_REQUEST.getToken(), value.getToken());
+    assertEquals("userAgent", value.getUserAgent());
+    assertEquals(user.getId(), value.getUser().getId());
+    assertTrue(value.getLastUsedAt().isAfter(now));
+  }
+}

--- a/src/test/java/homes/banzzokee/global/util/MockMvcUtil.java
+++ b/src/test/java/homes/banzzokee/global/util/MockMvcUtil.java
@@ -1,10 +1,12 @@
 package homes.banzzokee.global.util;
 
+import static org.springframework.http.HttpHeaders.USER_AGENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,5 +46,15 @@ public class MockMvcUtil {
   public static ResultActions performDelete(MockMvc mockMvc, String url)
       throws Exception {
     return mockMvc.perform(delete(url)).andDo(print());
+  }
+
+  public static ResultActions performPut(MockMvc mockMvc, String url, Object requestBody)
+      throws Exception {
+    return mockMvc.perform(
+            put(url)
+                .header(USER_AGENT, "spring boot unit test")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestBody)))
+        .andDo(print());
   }
 }


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
FCM 토큰 등록 기능을 구현했습니다.
- PUT 메서드를 이용해 UPSERT를 진행합니다.
- 프론트엔드에서는 PUT 메서드를 주기적으로 호출해서 토큰이 사용중임을 업데이트 합니다 (lastUsedAt)
- 사용일 및 어떤 기기에서 등록한 것인지 구분하기 위해 lastUsedAt 및 userAgent 필드를 추가했습니다.

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
FCM을 이용해서 알림 메시지를 보내는 경우 어떤 기기로 보내는지, 기기를 식별하기 위한 토큰정보가 필요합니다.
토큰 정보를 서버에 등록하고 관리할 수 있도록 관리해야합니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->
토큰이 오랫동안 사용되지 않는 경우 서버에서 토큰을 지우는 작업이 별도로 필요합니다. FCM 문서에서는 2개월을 권장합니다.
토큰 삭제 시 구독했던 토픽을 모두 구독 취소하는 작업도 필요합니다.

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->
해결한 이슈: #74 

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
<img width="1187" alt="image" src="https://github.com/banzzokee/banzzokee-back/assets/43163409/f86899f4-5bee-4341-a17d-ebc7ae301ead">

<img width="594" alt="image" src="https://github.com/banzzokee/banzzokee-back/assets/43163409/3d0b8713-c048-4926-a3d8-fbce4f3efe35">


## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
https://firebase.google.com/docs/cloud-messaging/manage-tokens?hl=ko