### PR TITLE
feature: signin oauth2

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -111,8 +111,8 @@ public class AuthService {
     if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new PasswordUnmatchedException();
     }
-    String accessToken = jwtTokenProvider.createAccessToken(user);
-    String refreshToken = jwtTokenProvider.createRefreshToken(user);
+    String accessToken = jwtTokenProvider.createAccessToken(user.getEmail());
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
     redisService.setRefreshToken(user.getEmail(), refreshToken, jwtTokenProvider.getRefreshTokenExpire());
     return TokenResponse.builder()
         .accessToken(accessToken)

--- a/src/main/java/homes/banzzokee/global/error/ErrorCode.java
+++ b/src/main/java/homes/banzzokee/global/error/ErrorCode.java
@@ -53,13 +53,15 @@ public enum ErrorCode {
   ADOPTION_DOCUMENT_NOT_FOUND(NOT_FOUND, "ElasticSearch에 저장된 분양게시글을 찾을 수가 없습니다."),
   ALREADY_ADOPTION_IS_FINISHED(BAD_REQUEST, "이미 분양완료된 게시글입니다."),
   NEED_TO_ASSIGNED_USER_INFO(BAD_REQUEST, "분양완료로 상태변경하기 위해서는 입양자 정보가 필요합니다."),
-  ASSIGNED_USER_MUST_BE_NULL(BAD_REQUEST,"분양중 또는 예약중으로 상태변경하기 위해서는 입양자 정보가 필요없습니다."),
+  ASSIGNED_USER_MUST_BE_NULL(BAD_REQUEST, "분양중 또는 예약중으로 상태변경하기 위해서는 입양자 정보가 필요없습니다."),
   BOOKMARK_ALREADY_EXISTS(BAD_REQUEST, "이미 저장된 북마크 입니다."),
   BOOKMARK_NOT_FOUND(NOT_FOUND, "북마크를 찾을 수 없습니다."),
   NO_SOCIAL_LOGIN_AUTHORIZED(FORBIDDEN, "잘못된 접근 방법입니다."),
+  EMAIL_EXIST_DIFFERENT_LOGIN(BAD_REQUEST, "등록된 이메일이 있습니다. 다른 방식으로 로그인 해주세요."),
   REVIEW_CAN_BE_WRITE_BY_ASSIGNED_USER(UNAUTHORIZED, "후기 게시글은 입양자만 작성 가능합니다."),
   ONLY_ONE_REVIEW_ALLOWED_PER_ADOPTION(BAD_REQUEST, "후기 게시글은 분양 게시글 당 하나만 작성 가능합니다."),
-  REVIEW_NOT_FOUND(NOT_FOUND, "후기 게시글이 존재하지 않습니다.")
+  REVIEW_NOT_FOUND(NOT_FOUND, "후기 게시글이 존재하지 않습니다."),
+
   ;
 
 

--- a/src/main/java/homes/banzzokee/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/homes/banzzokee/global/error/GlobalExceptionHandler.java
@@ -3,8 +3,7 @@ package homes.banzzokee.global.error;
 import static homes.banzzokee.global.error.ErrorCode.HTTP_MESSAGE_NOT_READABLE;
 import static homes.banzzokee.global.error.ErrorCode.INTERNAL_ERROR;
 import static homes.banzzokee.global.error.ErrorCode.JSON_EOF_ERROR;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.*;
 
 import com.fasterxml.jackson.core.io.JsonEOFException;
 import homes.banzzokee.global.config.stomp.exception.SocketException;
@@ -28,7 +27,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(CustomException e,
-      HttpServletRequest request) {
+                                                             HttpServletRequest request) {
     log.error("[CustomException] {} is occurred. uri:{}", e.getErrorCode(),
         request.getRequestURI());
 

--- a/src/main/java/homes/banzzokee/global/security/UserDetailsImpl.java
+++ b/src/main/java/homes/banzzokee/global/security/UserDetailsImpl.java
@@ -1,23 +1,58 @@
 package homes.banzzokee.global.security;
 
 import homes.banzzokee.domain.user.entity.User;
+
 import java.util.Collection;
 import java.util.List;
+
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Map;
 
 @Getter
-public class UserDetailsImpl implements UserDetails {
-
+public class UserDetailsImpl implements UserDetails, OAuth2User {
   private final Long userId;
   private final String username;
   private final List<GrantedAuthority> authorities;
+  private Map<String, Object> attributes;
 
+  /**
+   * 이메일 로그인
+   */
   public UserDetailsImpl(User user, List<GrantedAuthority> authorities) {
     this.userId = user.getId();
     this.username = user.getEmail();
     this.authorities = authorities;
+  }
+
+  /**
+   * 소셜 로그인
+   */
+  public UserDetailsImpl(User user, List<GrantedAuthority> authorities,
+                         Map<String, Object> attributes) {
+    this.userId = user.getId();
+    this.username = user.getEmail();
+    this.authorities = authorities;
+    this.attributes = attributes;
+  }
+
+  /**
+   * OAuth2
+   */
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  /**
+   * OAuth2
+   */
+  @Override
+  public String getName() {
+    return username;
   }
 
   /**

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
@@ -8,7 +8,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +21,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import static homes.banzzokee.global.security.oauth2.handler.OAuth2SuccessHandler.GOOGLE_URI;
 
 @Slf4j
 @Component
@@ -36,8 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
    */
   @Override
   protected void doFilterInternal(HttpServletRequest request,
-      HttpServletResponse response,
-      FilterChain filterChain) throws ServletException, IOException {
+                                  HttpServletResponse response,
+                                  FilterChain filterChain) throws ServletException, IOException {
     String token = resolveToken(request);
     if (token != null) {
       try {
@@ -47,7 +51,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throw e;
       }
     }
+    if (isRedirectToOAuth2CodeGoogle(request)) {
+      response.sendRedirect(GOOGLE_URI);
+      return;
+    }
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isRedirectToOAuth2CodeGoogle(HttpServletRequest request) {
+    return request.getRequestURI().equals(GOOGLE_URI);
   }
 
   /**

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package homes.banzzokee.global.security.jwt;
 
-import homes.banzzokee.domain.user.entity.User;
 import homes.banzzokee.global.security.UserDetailsServiceImpl;
 import homes.banzzokee.global.security.exception.AccessTokenExpiredException;
 import homes.banzzokee.global.security.exception.RefreshTokenExpiredException;
@@ -12,9 +11,11 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +23,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 @Getter
 @Component
@@ -40,20 +45,21 @@ public class JwtTokenProvider {
   @Value("${jwt.refreshTokenExpire}")
   private long refreshTokenExpire;
 
-  public String createAccessToken(User user) {
-    return createToken(user, accessTokenExpire);
+  public String createAccessToken(String email) {
+    return createToken(email, accessTokenExpire);
   }
 
-  public String createRefreshToken(User user) {
-    return createToken(user, refreshTokenExpire);
+  public String createRefreshToken(String email) {
+    return createToken(email, refreshTokenExpire);
   }
 
-  private String createToken(User user, long validity) {
+  private String createToken(String email, long validity) {
+    Claims claims = Jwts.claims().setSubject(email);
     Date now = new Date();
     Date expiryDate = new Date(now.getTime() + validity);
-
     return Jwts.builder()
-        .setSubject(user.getEmail())
+        .setClaims(claims)
+        .setSubject(email)
         .setExpiration(expiryDate)
         .signWith(getSecretKey())
         .compact();

--- a/src/main/java/homes/banzzokee/global/security/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,50 @@
+package homes.banzzokee.global.security.oauth2;
+
+import homes.banzzokee.domain.type.LoginType;
+import homes.banzzokee.domain.type.Role;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.global.security.exception.SocialLoginAuthorizedException;
+import jakarta.security.auth.message.AuthException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OAuth2UserInfo {
+
+  private final String email;
+  private final String nickname;
+  private final String profile;
+  private final LoginType loginType;
+
+  public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) throws AuthException {
+    return switch (registrationId) {
+      case "google" -> ofGoogle(attributes);
+      default -> throw new SocialLoginAuthorizedException();
+    };
+  }
+
+  private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+    return OAuth2UserInfo.builder()
+        .email((String) attributes.get("email"))
+        .profile((String) attributes.get("picture"))
+        .nickname((String) attributes.get("name"))
+        .loginType(LoginType.GOOGLE)
+        .build();
+  }
+
+  public User toEntity() {
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .profileImgUrl(profile)
+        .role(Set.of(Role.ROLE_USER))
+        .loginType(LoginType.GOOGLE)
+        .build();
+  }
+}

--- a/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2FailureHandler.java
@@ -1,0 +1,37 @@
+package homes.banzzokee.global.security.oauth2.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import homes.banzzokee.global.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+    response.setCharacterEncoding("UTF-8");
+    response.setContentType("application/json; charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    Map<String, String> errorMap = new HashMap<>();
+    errorMap.put("error", String.valueOf(ErrorCode.EMAIL_EXIST_DIFFERENT_LOGIN));
+    errorMap.put("message", ErrorCode.EMAIL_EXIST_DIFFERENT_LOGIN.getMessage());
+    String jsonErrorMessage = objectMapper.writeValueAsString(errorMap);
+    response.getWriter().write(jsonErrorMessage);
+    log.info("OAuth2FailureHandler: {}", exception.getMessage());
+  }
+}
+

--- a/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,41 @@
+package homes.banzzokee.global.security.oauth2.handler;
+
+import homes.banzzokee.global.security.UserDetailsImpl;
+import homes.banzzokee.global.security.jwt.JwtTokenProvider;
+import homes.banzzokee.global.util.redis.RedisService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  public static final String GOOGLE_URI = "/login/oauth2/code/google";
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RedisService redisService;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      Authentication authentication) throws IOException {
+    log.info("소셜 로그인 성공! 서버 로그를 확인해주세요.");
+    UserDetailsImpl oauth2User = (UserDetailsImpl) authentication.getPrincipal();
+    String accessToken = jwtTokenProvider.createAccessToken(oauth2User.getUsername());
+    String refreshToken = jwtTokenProvider.createAccessToken(oauth2User.getUsername());
+    redisService.setRefreshToken(oauth2User.getUsername(), refreshToken,
+        jwtTokenProvider.getRefreshTokenExpire());
+    String redirectUrl = UriComponentsBuilder.fromUriString(GOOGLE_URI)
+        .queryParam("accessToken", accessToken)
+        .build().toUriString();
+    response.sendRedirect(redirectUrl);
+  }
+}

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
@@ -1,0 +1,67 @@
+package homes.banzzokee.global.security.oauth2.service;
+
+import homes.banzzokee.domain.type.Role;
+import homes.banzzokee.domain.user.dao.UserRepository;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.global.security.UserDetailsImpl;
+import homes.banzzokee.global.security.exception.SocialLoginAuthorizedException;
+import homes.banzzokee.global.security.oauth2.OAuth2UserInfo;
+import jakarta.security.auth.message.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static homes.banzzokee.global.error.ErrorCode.EMAIL_EXIST_DIFFERENT_LOGIN;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuth2UserDetailsServiceImpl extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    OAuth2UserInfo oAuth2UserInfo;
+    try {
+      oAuth2UserInfo = OAuth2UserInfo.of(registrationId, oAuth2UserAttributes);
+    } catch (AuthException e) {
+      throw new SocialLoginAuthorizedException();
+    }
+    User user = getOrSave(oAuth2UserInfo);
+    return new UserDetailsImpl(user, List.of(new SimpleGrantedAuthority(Role.ROLE_USER.name()))
+        , oAuth2UserAttributes);
+  }
+
+  private User getOrSave(OAuth2UserInfo oAuth2UserInfo) {
+    String email = oAuth2UserInfo.getEmail();
+    Optional<User> findUser = userRepository.findByEmail(email);
+    if (findUser.isPresent()) {
+      User existingUser = findUser.get();
+      // 이미 등록된 이메일이지만 로그인 타입이 다르면 예외 발생
+      if (!oAuth2UserInfo.getLoginType().equals(existingUser.getLoginType())) {
+        OAuth2Error oauthError = new OAuth2Error(
+            "invalid_request", EMAIL_EXIST_DIFFERENT_LOGIN.getMessage(), null);
+        throw new OAuth2AuthenticationException(oauthError);
+      }
+      // 등록된 사용자이면 해당 사용자 반환
+      return existingUser;
+    } else {
+      // 등록되지 않은 사용자이면 새로운 사용자를 생성하여 저장
+      User newUser = oAuth2UserInfo.toEntity();
+      return userRepository.save(newUser);
+    }
+  }
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,12 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_OAUTH2_CLIENT_ID}
+            client-secret: ${GOOGLE_OAUTH2_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope:
+              - profile
+              - email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,4 @@ spring:
       - jwt
       - elasticsearch
       - rabbitmq
+      - oauth2

--- a/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
@@ -246,8 +246,8 @@ class AuthServiceTest {
 
     given(userRepository.findByEmail(signInRequest.getEmail())).willReturn(Optional.of(user));
     given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-    given(jwtTokenProvider.createAccessToken(any(User.class))).willReturn(tokenResponse.getAccessToken());
-    given(jwtTokenProvider.createRefreshToken(any(User.class))).willReturn(tokenResponse.getRefreshToken());
+    given(jwtTokenProvider.createAccessToken(anyString())).willReturn(tokenResponse.getAccessToken());
+    given(jwtTokenProvider.createRefreshToken(anyString())).willReturn(tokenResponse.getRefreshToken());
 
     // when
     TokenResponse result = authService.signIn(signInRequest);

--- a/src/test/java/homes/banzzokee/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/bookmark/service/BookmarkServiceTest.java
@@ -58,12 +58,7 @@ class BookmarkServiceTest {
   @DisplayName("[북마크 등록] - 성공 검증")
   void registerBookmark_when_success_then_verify() {
     // given
-    User user = User.builder()
-        .email("test@gmail.com")
-        .nickname("반쪽이")
-        .role(Set.of(ROLE_USER))
-        .loginType(LoginType.EMAIL)
-        .build();
+    User user = mock(User.class);
 
     Adoption adoption = Adoption.builder()
         .title("강아지")
@@ -81,19 +76,19 @@ class BookmarkServiceTest {
         .adoptionId(1L)
         .build();
 
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-    when(adoptionRepository.findById(bookmarkRegisterRequest.getAdoptionId())).thenReturn(Optional.of(adoption));
-    when(bookmarkRepository.findByUserIdAndAdoptionId(1L, bookmarkRegisterRequest.getAdoptionId())).thenReturn(Optional.empty());
+    when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+    when(adoptionRepository.findById(bookmarkRegisterRequest.getAdoptionId()))
+        .thenReturn(Optional.of(adoption));
+    when(bookmarkRepository.findByUserIdAndAdoptionId(anyLong(),
+        eq(bookmarkRegisterRequest.getAdoptionId()))).thenReturn(Optional.ofNullable(null));
 
-    UserDetailsImpl userDetails = new UserDetailsImpl(user,
-        List.of(new SimpleGrantedAuthority(ROLE_USER.name())));
+    UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
 
     // when
     bookmarkService.registerBookmark(userDetails, bookmarkRegisterRequest);
 
     // then
     verify(bookmarkRepository).save(any(Bookmark.class));
-
   }
 
   @Test

--- a/src/test/java/homes/banzzokee/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/bookmark/service/BookmarkServiceTest.java
@@ -27,6 +27,10 @@ import org.springframework.data.domain.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.*;
 
 import static homes.banzzokee.domain.type.Role.ROLE_USER;
@@ -81,8 +85,8 @@ class BookmarkServiceTest {
     when(adoptionRepository.findById(bookmarkRegisterRequest.getAdoptionId())).thenReturn(Optional.of(adoption));
     when(bookmarkRepository.findByUserIdAndAdoptionId(1L, bookmarkRegisterRequest.getAdoptionId())).thenReturn(Optional.empty());
 
-    UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
-    given(userDetails.getUserId()).willReturn(1L);
+    UserDetailsImpl userDetails = new UserDetailsImpl(user,
+        List.of(new SimpleGrantedAuthority(ROLE_USER.name())));
 
     // when
     bookmarkService.registerBookmark(userDetails, bookmarkRegisterRequest);
@@ -96,8 +100,14 @@ class BookmarkServiceTest {
   @DisplayName("[북마크 등록] - 회원 정보가 없는 경우 UserNotFoundException 발생")
   void registerBookmark_when_verifyUser_then_UserNotFoundException() {
     // given
-    UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
-    given(userDetails.getUserId()).willReturn(1L);
+    User user = User.builder()
+        .email("test@gmail.com")
+        .nickname("반쪽이")
+        .role(Set.of(ROLE_USER))
+        .loginType(LoginType.EMAIL)
+        .build();
+    UserDetailsImpl userDetails = new UserDetailsImpl(user,
+        List.of(new SimpleGrantedAuthority(ROLE_USER.name())));
     BookmarkRegisterRequest bookmarkRegisterRequest = BookmarkRegisterRequest
         .builder()
         .adoptionId(1L)
@@ -123,7 +133,6 @@ class BookmarkServiceTest {
         .build();
     UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
     given(userDetails.getUserId()).willReturn(1L);
-
     BookmarkRegisterRequest bookmarkRegisterRequest = BookmarkRegisterRequest
         .builder()
         .adoptionId(1L)


### PR DESCRIPTION
## Changes
- 인가 코드 발급 하는 부분 동작 완료
- code = 엑세스 토큰 발급하고 나서 토큰 확인 완료
- 리프레쉬 토큰 레디스에 저장 및 로그인 성공 시 db 에 저장 완료
- oauth2 구글 로그인 기능 구현을 완벽히 하지 못한 상황이지만, (닉네임 중복처리) 너무 오랜 시간 동안 해결 되지 않아 현재 진행된 부분 공유 하기 위하여 push 하려고 합니다.
- 기존에 작성했던 리다이렉트 url (api/auth/callback/google) 에서 url 을 oauth2-client 에서 기본으로 제공해주는 리다이렉트 url 이 있어 "/login/oauth2/code/google" 해당 url 을 사용하였습니다.
- 프론트 단에서 구글 로그인 버튼 url 을 /oauth2/authorization/google url 로 로그인 요청을 보내야 동작 합니다. (/oauth2/authorization/google url 은 로그인 페이지 제공해주는 url 이라고 합니다.)

## Background
- 소셜 로그인 (google) 하기 위한 api
## Discuss
- 닉네임 중복확인 부분 해결하지 못하였습니다. 닉네임 중복 확인하는 페이지로 (AuthController 호출?) redirect 해서 진행해야 되는건지 의문이였습니다.

- 일 부분 페이지 띄우거나, 포스트맨으로 테스트를 하긴 하였는데 소셜 로그인 적용 후 테스트를 이렇게 하는게 맞는지 의문입니다.

- 소셜 로그인을 할 경우 레디스에 리프레쉬 토큰을 저장하도록 구현을 하였는데 계속 해보면서 그게 맞는지에 대한 의문이 들었습니다. 구글, 카카오, 네이버에서 제공해주는 로그인 인데 토큰을 가지고 있어서 뭐하지?, 레디스 서버에서 관리 할 필요가 있을까?? 라는 생각이 들었습니다.
## Issues
#16 

## Execute
<img width="500" alt="테스트foem" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/d7a104ad-a7f1-41e8-b9f9-b6308a9482c7">
<img width="500" alt="로그인페이지" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/d6eedb8a-16a5-4401-833c-021ce6b91e83">
<img width="500" alt="구글로그인시(인가코드 요청시)" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/d35da354-6745-45b8-ad16-3c6bcaa2f31c">
<img width="500" alt="db에_저장" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/10c18d11-f5bb-4908-a087-2772adc15447">
<img width="500" alt="소셜로그인_인가코드 _발급확인" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/29adcf16-eba5-4c85-ac0f-345ec5b00edf">
<img width="500" alt="레디스_리프레쉬_토큰_저장" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/6dbcdb54-a282-4b52-ad41-09b59c9c530b">