### PR TITLE
feature: 본인 프로필 조회 추가

### DIFF
--- a/src/main/java/homes/banzzokee/domain/user/controller/UserController.java
+++ b/src/main/java/homes/banzzokee/domain/user/controller/UserController.java
@@ -36,6 +36,12 @@ public class UserController {
     return userService.getUserProfile(userId);
   }
 
+  @GetMapping("me")
+  public UserProfileDto getMyProfile(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return userService.getUserProfile(userDetails.getUserId());
+  }
+
   @PostMapping("me/withdraw")
   public UserWithdrawResponse withdrawalUser(
       @Valid @RequestBody UserWithdrawRequest request,

--- a/src/test/java/homes/banzzokee/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/user/controller/UserControllerTest.java
@@ -107,6 +107,57 @@ class UserControllerTest {
   }
 
   @Test
+  @DisplayName("[본인 프로필 조회] - 성공 검증")
+  @WithMockCustomUser
+  void getMyProfile_when_validInput_then_success() throws Exception {
+    // given
+    ShelterDto shelter = ShelterDto.builder()
+        .shelterId(1L)
+        .shelterImgUrl("shelter.png")
+        .name("반쪽이 보호소")
+        .description("반쪽이 화이팅")
+        .tel("02-1234-5678")
+        .address("서울시 행복구")
+        .registeredAt(LocalDate.of(2024, 1, 1))
+        .build();
+
+    UserProfileDto profile = UserProfileDto.builder()
+        .userId(1L)
+        .email("user1@banzzokee.homes")
+        .profileImgUrl("avatar.png")
+        .nickname("사용자1")
+        .introduce("안녕하세요")
+        .joinedAt(LocalDate.of(2024, 1, 1))
+        .shelter(shelter)
+        .build();
+
+    given(userService.getUserProfile(profile.getUserId()))
+        .willReturn(profile);
+
+    // when
+    ResultActions resultActions = MockMvcUtil.performGet(mockMvc, "/api/users/me");
+
+    // then
+    verify(userService).getUserProfile(profile.getUserId());
+
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(profile.getUserId()))
+        .andExpect(jsonPath("$.email").value(profile.getEmail()))
+        .andExpect(jsonPath("$.profileImgUrl").value(profile.getProfileImgUrl()))
+        .andExpect(jsonPath("$.nickname").value(profile.getNickname()))
+        .andExpect(jsonPath("$.introduce").value(profile.getIntroduce()))
+        .andExpect(jsonPath("$.joinedAt").value(profile.getJoinedAt().toString()))
+        .andExpect(jsonPath("$.shelter.shelterId").value(shelter.getShelterId()))
+        .andExpect(jsonPath("$.shelter.shelterImgUrl").value(shelter.getShelterImgUrl()))
+        .andExpect(jsonPath("$.shelter.name").value(shelter.getName()))
+        .andExpect(jsonPath("$.shelter.description").value(shelter.getDescription()))
+        .andExpect(jsonPath("$.shelter.tel").value(shelter.getTel()))
+        .andExpect(jsonPath("$.shelter.address").value(shelter.getAddress()))
+        .andExpect(jsonPath("$.shelter.registeredAt")
+            .value(shelter.getRegisteredAt().toString()));
+  }
+
+  @Test
   @DisplayName("[사용자 탈퇴] - 성공 검증")
   @WithMockCustomUser
   void withdrawUser_when_validInput_then_success() throws Exception {


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
- 로그인한 사용자 본인 프로필을 조회하는 API를 추가했습니다.
- GET /api/users/me

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
기존에 사용자 프로필 조회를 GET /api/users/{userId}로 추가했으나, AccessToken에 userId 정보가 담겨있지 않아서 프론트엔드에서 사용자 프로필을 조회하지 못하는 문제가 있었습니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->
해결한 이슈: #140 

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->

## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
