### PR TITLE
feature: signin oauth2

### DIFF
--- a/src/main/java/homes/banzzokee/domain/user/dao/UserRepository.java
+++ b/src/main/java/homes/banzzokee/domain/user/dao/UserRepository.java
@@ -1,8 +1,11 @@
 package homes.banzzokee.domain.user.dao;
 
 import homes.banzzokee.domain.shelter.entity.Shelter;
+import homes.banzzokee.domain.type.LoginType;
 import homes.banzzokee.domain.user.entity.User;
+
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
   Optional<User> findByEmail(String email);
+
+  boolean existsByEmailAndLoginType(String email, LoginType loginType);
 }

--- a/src/main/java/homes/banzzokee/domain/user/entity/User.java
+++ b/src/main/java/homes/banzzokee/domain/user/entity/User.java
@@ -207,4 +207,11 @@ public class User extends BaseEntity {
     this.shelter.delete();
     this.role.remove(ROLE_SHELTER);
   }
+
+  /**
+   * 최초 소셜로그인 닉네임 등록
+   */
+  public void updateNickname(String nickname) {
+    this.nickname = nickname;
+  }
 }

--- a/src/main/java/homes/banzzokee/global/security/UserDetailsImpl.java
+++ b/src/main/java/homes/banzzokee/global/security/UserDetailsImpl.java
@@ -18,6 +18,7 @@ public class UserDetailsImpl implements UserDetails, OAuth2User {
   private final String username;
   private final List<GrantedAuthority> authorities;
   private Map<String, Object> attributes;
+  private boolean isFirstLogin;
 
   /**
    * 이메일 로그인
@@ -32,11 +33,12 @@ public class UserDetailsImpl implements UserDetails, OAuth2User {
    * 소셜 로그인
    */
   public UserDetailsImpl(User user, List<GrantedAuthority> authorities,
-                         Map<String, Object> attributes) {
+                         Map<String, Object> attributes, boolean isFirstLogin) {
     this.userId = user.getId();
     this.username = user.getEmail();
     this.authorities = authorities;
     this.attributes = attributes;
+    this.isFirstLogin = isFirstLogin;
   }
 
   /**

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
@@ -22,8 +22,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import static homes.banzzokee.global.security.oauth2.handler.OAuth2SuccessHandler.GOOGLE_URI;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -51,15 +49,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throw e;
       }
     }
-    if (isRedirectToOAuth2CodeGoogle(request)) {
-      response.sendRedirect(GOOGLE_URI);
-      return;
-    }
-    filterChain.doFilter(request, response);
-  }
 
-  private boolean isRedirectToOAuth2CodeGoogle(HttpServletRequest request) {
-    return request.getRequestURI().equals(GOOGLE_URI);
+    filterChain.doFilter(request, response);
   }
 
   /**
@@ -82,7 +73,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     jwtTokenProvider.validateToken(token);
     String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
     UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
-    Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    Authentication authentication = new UsernamePasswordAuthenticationToken(
+        userDetails, null, userDetails.getAuthorities());
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
@@ -1,0 +1,23 @@
+package homes.banzzokee.global.security.oauth2.controller;
+
+import homes.banzzokee.domain.auth.dto.TokenResponse;
+import homes.banzzokee.global.security.oauth2.dto.NicknameRequest;
+import homes.banzzokee.global.security.oauth2.service.Oauth2Service;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+public class OAuth2Controller {
+
+  private final Oauth2Service oauth2Service;
+
+  @PostMapping("/sign-up")
+  public ResponseEntity<TokenResponse> signup(@RequestHeader("Authorization") String token,
+                                              @Valid @RequestBody NicknameRequest nicknameRequest) {
+    return ResponseEntity.ok(oauth2Service.signup(token,nicknameRequest));
+  }
+}

--- a/src/main/java/homes/banzzokee/global/security/oauth2/dto/NicknameRequest.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/dto/NicknameRequest.java
@@ -1,0 +1,18 @@
+package homes.banzzokee.global.security.oauth2.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameRequest {
+
+  @Length(max = 10, message = "닉네임은 최대 10자리까지 가능합니다.")
+  private String nickname;
+
+}

--- a/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-  public static final String GOOGLE_URI = "/login/oauth2/code/google";
+  public static final String SUCCESS_URI = "/oauth2/success";
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
 
@@ -33,7 +33,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String refreshToken = jwtTokenProvider.createAccessToken(oauth2User.getUsername());
     redisService.setRefreshToken(oauth2User.getUsername(), refreshToken,
         jwtTokenProvider.getRefreshTokenExpire());
-    String redirectUrl = UriComponentsBuilder.fromUriString(GOOGLE_URI)
+    String redirectUrl = UriComponentsBuilder.fromUriString(SUCCESS_URI)
         .queryParam("accessToken", accessToken)
         .build().toUriString();
     response.sendRedirect(redirectUrl);

--- a/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -33,6 +33,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String redirectUrl;
     if (isFirstSocialLogin) {
       redirectUrl = SUCCESS_URI + "?accessToken=" + accessToken + "&isFirstLogin=true";
+      String refreshToken = jwtTokenProvider.createRefreshToken(oauth2User.getUsername());
+      redisService.setRefreshToken(
+          oauth2User.getUsername(), refreshToken, jwtTokenProvider.getRefreshTokenExpire());
     } else {
       redirectUrl = SUCCESS_URI + "?accessToken=" + accessToken + "&isFirstLogin=false";
     }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
@@ -45,21 +45,21 @@ public class OAuth2UserDetailsServiceImpl extends DefaultOAuth2UserService {
         , oAuth2UserAttributes);
   }
 
+  /**
+   * 최초 소셜로그인 구분 로직
+   */
   private User getOrSave(OAuth2UserInfo oAuth2UserInfo) {
     String email = oAuth2UserInfo.getEmail();
     Optional<User> findUser = userRepository.findByEmail(email);
     if (findUser.isPresent()) {
       User existingUser = findUser.get();
-      // 이미 등록된 이메일이지만 로그인 타입이 다르면 예외 발생
       if (!oAuth2UserInfo.getLoginType().equals(existingUser.getLoginType())) {
         OAuth2Error oauthError = new OAuth2Error(
             "invalid_request", EMAIL_EXIST_DIFFERENT_LOGIN.getMessage(), null);
         throw new OAuth2AuthenticationException(oauthError);
       }
-      // 등록된 사용자이면 해당 사용자 반환
       return existingUser;
     } else {
-      // 등록되지 않은 사용자이면 새로운 사용자를 생성하여 저장
       User newUser = oAuth2UserInfo.toEntity();
       return userRepository.save(newUser);
     }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/OAuth2UserDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package homes.banzzokee.global.security.oauth2.service;
 
+import homes.banzzokee.domain.type.LoginType;
 import homes.banzzokee.domain.type.Role;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.entity.User;
@@ -40,9 +41,10 @@ public class OAuth2UserDetailsServiceImpl extends DefaultOAuth2UserService {
     } catch (AuthException e) {
       throw new SocialLoginAuthorizedException();
     }
+    boolean isFirstLongin = checkIfFirstSocialLogin(oAuth2UserInfo.getEmail());
     User user = getOrSave(oAuth2UserInfo);
     return new UserDetailsImpl(user, List.of(new SimpleGrantedAuthority(Role.ROLE_USER.name()))
-        , oAuth2UserAttributes);
+        , oAuth2UserAttributes, isFirstLongin);
   }
 
   /**
@@ -63,5 +65,9 @@ public class OAuth2UserDetailsServiceImpl extends DefaultOAuth2UserService {
       User newUser = oAuth2UserInfo.toEntity();
       return userRepository.save(newUser);
     }
+  }
+
+  public boolean checkIfFirstSocialLogin(String email) {
+    return !userRepository.existsByEmailAndLoginType(email, LoginType.GOOGLE);
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class Oauth2Service {
 
-  private static final int BEARER_LENGTH = 7;
+  public static final int BEARER_LENGTH = 7;
 
   private final RedisService redisService;
   private final UserRepository userRepository;

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
@@ -1,0 +1,39 @@
+package homes.banzzokee.global.security.oauth2.service;
+
+import homes.banzzokee.domain.auth.dto.TokenResponse;
+import homes.banzzokee.domain.auth.exception.EmailNotFoundException;
+import homes.banzzokee.domain.user.dao.UserRepository;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.global.security.jwt.JwtTokenProvider;
+import homes.banzzokee.global.security.oauth2.dto.NicknameRequest;
+import homes.banzzokee.global.util.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class Oauth2Service {
+
+  private static final int BEARER_LENGTH = 7;
+
+  private final RedisService redisService;
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Transactional
+  public TokenResponse signup(String token, NicknameRequest nicknameRequest) {
+    String email = jwtTokenProvider.getUserEmailFromToken(token.substring(BEARER_LENGTH));
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(EmailNotFoundException::new);
+    user.updateNickname(nicknameRequest.getNickname());
+    userRepository.save(user);
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+    redisService.setRefreshToken(
+        user.getEmail(), refreshToken, jwtTokenProvider.getRefreshTokenExpire());
+    return TokenResponse.builder()
+        .accessToken(jwtTokenProvider.createAccessToken(user.getEmail()))
+        .refreshToken(refreshToken)
+        .build();
+  }
+}

--- a/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
+++ b/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
@@ -54,4 +54,8 @@ public class RedisService {
   public boolean isRefreshTokenExist(String email, String token) {
     return this.getRefreshToken(email) != null && this.getRefreshToken(email).equals(token);
   }
+
+  public boolean hasUserEmail(String email) {
+    return Boolean.TRUE.equals(redisTemplate.hasKey(email));
+  }
 }


### PR DESCRIPTION
## Changes
- 소셜 로그인 관련한 성공 시 SuccessHandler URI 수정하였습니다.
- 최초 소셜로그인 일 경우 닉네임 등록 API 추가하였습니다.
  - 프론트에서 넘겨준 accessToken 과 닉네임을 요청 받아서 토큰을 반환하도록 하였습니다. 
- 최초 소셜로그인 로그인이 성공할 경우 토큰 + true 반환 하도록 하였습니다.
  - 최초 로그인이 아닐 시 토큰 + false 반환하여 최초인지 기존에 있던 사용자인지 확인 할 수 있도록 하였습니다. 
 - 레디스에 토큰이 있는지 확인 후 boolean 반환하는 기능 및  최초 소셜로그인시 토큰 생성하여 redis 에 저장하도록 하였습니다.

## Background
- 일반 로그인이 아닌 소셜로그인을 하기 위하여 추가하였습니다.

## Issues
해결한 이슈: #148 

## Execute
- 페이지가 없어서 x 로 뜨는 상황입니다. 페이로드에서 정상적인 값 확인하였습니다.
<img width="600" alt="최초_소셜로그인_아닐경우" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/0bd671b7-e87e-4fe1-bf67-02f7dd78f363">
<img width="600" alt="최초_소셜로그인_일경우" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/127b938f-1b1f-4f84-b6b5-5186a8178e34">
<img width="600" alt="최초_소셜로그인_일경우_닉네임등록_테스트" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/20bd7d7f-9752-4370-b9ea-c75b2024c332">
<img width="600" alt="최초_소셜로그인_일경우_닉네임_변경_적용" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/7aee924f-281f-42cb-8213-327976b41e8f">


## Reference
https://ksh-coding.tistory.com/66
https://lovelyalien.tistory.com/81
https://velog.io/@ljm0726/Spring-Security-OAuth2-JWT