### PR TITLE
feature: logout

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -43,4 +43,10 @@ public class AuthController {
   public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody SignInRequest signInRequest) {
     return ResponseEntity.ok(authService.signIn(signInRequest));
   }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
+    authService.logout(token);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
+++ b/src/main/java/homes/banzzokee/domain/auth/service/AuthService.java
@@ -120,13 +120,10 @@ public class AuthService {
         .build();
   }
 
-  /**
-   * 로그아웃
-   *
-   * @param token
-   */
   public void logout(String token) {
-    redisService.addToBlacklist(token);
-    redisService.deleteRefreshToken(token);
+    String cleanedToken = jwtTokenProvider.removeBearerFromToken(token);
+    jwtTokenProvider.validateToken(cleanedToken);
+    redisService.addToBlacklist(cleanedToken);
+    redisService.deleteRefreshToken(jwtTokenProvider.getUserEmailFromToken(cleanedToken));
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
@@ -27,13 +27,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import static homes.banzzokee.global.security.jwt.JwtTokenProvider.BEARER_LENGTH;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private static final String BEARER = "Bearer ";
-  private static final int TOKEN_SPLIT_DEFAULT_VALUE = 7;
 
   private final JwtTokenProvider jwtTokenProvider;
   private final UserDetailsServiceImpl userDetailsService;
@@ -78,7 +79,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private String resolveToken(HttpServletRequest request) {
     String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
-      return bearerToken.substring(TOKEN_SPLIT_DEFAULT_VALUE);
+      return bearerToken.substring(BEARER_LENGTH);
     }
     return null;
   }

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtTokenProvider.java
@@ -24,14 +24,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-
 @Getter
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
+
+  public static final int BEARER_LENGTH = 7;
 
   private final RedisService redisService;
   private final UserDetailsServiceImpl userDetailsService;
@@ -106,5 +104,9 @@ public class JwtTokenProvider {
     return new UsernamePasswordAuthenticationToken(
         userDetails, "", userDetails.getAuthorities()
     );
+  }
+
+  public String removeBearerFromToken(String token) {
+    return token.substring(BEARER_LENGTH);
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/service/Oauth2Service.java
@@ -15,15 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class Oauth2Service {
 
-  public static final int BEARER_LENGTH = 7;
-
   private final RedisService redisService;
   private final UserRepository userRepository;
   private final JwtTokenProvider jwtTokenProvider;
 
   @Transactional
   public TokenResponse signup(String token, NicknameRequest nicknameRequest) {
-    String email = jwtTokenProvider.getUserEmailFromToken(token.substring(BEARER_LENGTH));
+    String email = jwtTokenProvider.getUserEmailFromToken(
+        jwtTokenProvider.removeBearerFromToken(token));
     User user = userRepository.findByEmail(email)
         .orElseThrow(EmailNotFoundException::new);
     user.updateNickname(nicknameRequest.getNickname());

--- a/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
+++ b/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
@@ -39,8 +39,8 @@ public class RedisService {
     return redisTemplate.opsForValue().get(key);
   }
 
-  public void deleteRefreshToken(String key) {
-    redisTemplate.delete(key);
+  public void deleteRefreshToken(String email) {
+    redisTemplate.delete(email);
   }
 
   public void addToBlacklist(String token) {

--- a/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
+++ b/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
@@ -11,6 +11,8 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisService {
 
+  private static final int BLACKLIST_TOKEN_EXPIRE = 86400;
+
   private final RedisTemplate<String, String> redisTemplate;
 
   public void setData(String key, String value, long duration) {
@@ -44,7 +46,8 @@ public class RedisService {
   }
 
   public void addToBlacklist(String token) {
-    redisTemplate.opsForValue().set(token, "blacklisted");
+    redisTemplate.opsForValue().set(token, "blacklisted", BLACKLIST_TOKEN_EXPIRE,
+        TimeUnit.SECONDS);
   }
 
   public boolean isBlacklisted(String token) {

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -160,4 +160,20 @@ class AuthControllerTest {
         .andExpect(jsonPath("$.accessToken").value("!@#$%^&*()1234567890"))
         .andExpect(jsonPath("$.refreshToken").value("1234567890)(*&^%$#@!"));
   }
+
+  @Test
+  @WithMockUser
+  @DisplayName("[로그아웃] - 성공 검증")
+  void logout_when_valid_then_success() throws Exception {
+    // given
+    String token = "Bearer testToken";
+
+    // when
+    doNothing().when(authService).logout(token);
+
+    // then
+    mockMvc.perform(post("/api/auth/logout")
+            .header("Authorization", token))
+        .andExpect(status().isOk());
+  }
 }

--- a/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/service/AuthServiceTest.java
@@ -292,4 +292,29 @@ class AuthServiceTest {
     // then & then
     assertThrows(PasswordUnmatchedException.class, () -> authService.signIn(signInRequest));
   }
+
+  @Test
+  @DisplayName("[로그아웃] - 성공 검증")
+  public void logout_when_success_then_verify() {
+    // given
+    String token = "testToken";
+    String email = "testEmail";
+    String cleanedToken = "cleanedTestToken";
+
+    // when
+    given(jwtTokenProvider.removeBearerFromToken(token)).willReturn(cleanedToken);
+    doNothing().when(jwtTokenProvider).validateToken(cleanedToken);
+    doNothing().when(redisService).addToBlacklist(cleanedToken);
+    given(jwtTokenProvider.getUserEmailFromToken(cleanedToken)).willReturn(email);
+    doNothing().when(redisService).deleteRefreshToken(email);
+
+    // then
+    authService.logout(token);
+
+    verify(jwtTokenProvider).removeBearerFromToken("testToken");
+    verify(jwtTokenProvider).validateToken("cleanedTestToken");
+    verify(redisService).addToBlacklist("cleanedTestToken");
+    verify(jwtTokenProvider).getUserEmailFromToken("cleanedTestToken");
+    verify(redisService).deleteRefreshToken("testEmail");
+  }
 }


### PR DESCRIPTION
## Changes
- 로그아웃 API 를 추가하였습니다.
- 로그아웃 할 경우 레디스에서 리프레시 토큰 삭제 및 엑세스 토큰 블랙리스트로 추가하였습니다.
- 토큰 요청 받아서 Bearer 자르는 기능 중복되는 코드에서 메소드 토큰 자르는 메소드를 만들어 중복 제거 하였습니다.

## Background
- 로그아웃 할 경우 토큰 제거 및 엑세스 토큰 블랙리스트 추가하기 위함

## Issues
해결한 이슈: #146 

## Execute
<img width="600" alt="레디스_블랙리스트_추가" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/f2d5a623-9d53-4cb0-a558-dd6c24c4bf44">
<img width="600" alt="로그아웃_포스트맨_테스트" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/7a88a4bc-16ea-4b1d-9c7a-fce3960f505b">



## Reference
https://velog.io/@boo105/Redis-%EB%A5%BC-%ED%86%B5%ED%95%9C-JWT-Blacklist-%EA%B5%AC%ED%98%84