### PR TITLE
feature: token reissu

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -49,4 +49,10 @@ public class AuthController {
     authService.logout(token);
     return ResponseEntity.ok().build();
   }
+
+  @PostMapping("/token/reissue")
+  public ResponseEntity<TokenResponse> reissueAccessToken(@RequestHeader("Authorization")
+                                                            String refreshToken) {
+    return ResponseEntity.ok(authService.reissueAccessToken(refreshToken));
+  }
 }

--- a/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
+++ b/src/main/java/homes/banzzokee/global/util/redis/RedisService.java
@@ -19,11 +19,6 @@ public class RedisService {
     redisTemplate.opsForValue().set(key, value, duration, TimeUnit.SECONDS);
   }
 
-  public void setDataExpire(String key, String value, long duration) {
-    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-    valueOperations.set(key, value, duration, TimeUnit.SECONDS);
-  }
-
   public String getData(String key) {
     ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
     return valueOperations.get(key);
@@ -50,15 +45,7 @@ public class RedisService {
         TimeUnit.SECONDS);
   }
 
-  public boolean isBlacklisted(String token) {
-    return Boolean.TRUE.equals(redisTemplate.hasKey(token));
-  }
-
   public boolean isRefreshTokenExist(String email, String token) {
     return this.getRefreshToken(email) != null && this.getRefreshToken(email).equals(token);
-  }
-
-  public boolean hasUserEmail(String email) {
-    return Boolean.TRUE.equals(redisTemplate.hasKey(email));
   }
 }

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -176,4 +176,23 @@ class AuthControllerTest {
             .header("Authorization", token))
         .andExpect(status().isOk());
   }
+
+  @Test
+  @WithMockUser
+  @DisplayName("[토큰 재발급] - 성공 검증")
+  void tokenReissue_when_validInput_then_success() throws Exception {
+    // given
+    String refreshToken = "Bearer refreshToken";
+    TokenResponse tokenResponse = new TokenResponse(
+        "newAccessToken", "refreshToken");
+    given(authService.reissueAccessToken(anyString())).willReturn(tokenResponse);
+
+    // when & then
+    mockMvc.perform(post("/api/auth/token/reissue")
+            .header("Authorization", refreshToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("newAccessToken"))
+        .andExpect(jsonPath("$.refreshToken").value("refreshToken"));
+    verify(authService).reissueAccessToken(refreshToken);
+  }
 }


### PR DESCRIPTION
## Changes
- 엑세스 토큰 재발급 API 를 추가하였습니다.
- 헤더를 통해 리프레시 토큰을 요청 받도록 하였습니다.
- 기존에 있던 TokenResponse 를 재활용하여 새로 발급한 엑세스 토큰과 리프레시 토큰을 같이 반환 하도록 하였습니다.
- 리프레시 토큰이 레디스에 존재 하지 않을 경우 다시 로그인 하라는 예외 메시지를 전달하였습니다.

## Background
- 엑세스 토큰이 만료되어 접근 불가할 때 리프레시 토큰을 활용하여 엑세스 토큰 재발급 하기 위함

## Issues
해결한 이슈: #147 

## Execute
<img width="600" alt="토큰이_만료되었을때" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/a6368ef4-cf47-482b-b26c-706fb1c5fccf">
<img width="600" alt="리프레시_토큰이_레디스에_없는경우" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/e50fbc9f-a33f-45d3-8e2a-f764346f1f0f">
<img width="600" alt="엑세스토큰_재발급_할경우" src="https://github.com/banzzokee/banzzokee-back/assets/78896254/80abaa31-a9b2-4b87-81e3-2c5a5c4e11f4">