### PR TITLE
feature: get follow list

### DIFF
--- a/src/main/java/homes/banzzokee/domain/adoption/dto/AdoptionDto.java
+++ b/src/main/java/homes/banzzokee/domain/adoption/dto/AdoptionDto.java
@@ -1,6 +1,8 @@
 package homes.banzzokee.domain.adoption.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import homes.banzzokee.domain.adoption.entity.Adoption;
+import homes.banzzokee.domain.bookmark.entity.Bookmark;
 import homes.banzzokee.domain.type.AdoptionStatus;
 import homes.banzzokee.domain.type.BreedType;
 import homes.banzzokee.domain.type.DogGender;
@@ -17,6 +19,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class AdoptionDto {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final Long bookmarkId;
 
   private final Long adoptionId;
 
@@ -54,6 +59,29 @@ public class AdoptionDto {
 
   public static AdoptionDto fromEntity(Adoption adoption) {
     return AdoptionDto.builder()
+        .adoptionId(adoption.getId())
+        .userId(adoption.getUser().getId())
+        .userNickname(adoption.getUser().getNickname())
+        .title(adoption.getTitle())
+        .content(adoption.getContent())
+        .imageUrls(getImageUrlList(adoption))
+        .status(adoption.getStatus())
+        .breed(adoption.getBreed())
+        .size(adoption.getSize())
+        .neutering(adoption.isNeutering())
+        .gender(adoption.getGender())
+        .age(adoption.getAge())
+        .healthChecked(adoption.isHealthChecked())
+        .registeredAt(adoption.getRegisteredAt())
+        .adoptedAt(adoption.getAdoptedAt())
+        .createdAt(adoption.getCreatedAt())
+        .updatedAt(adoption.getUpdatedAt())
+        .build();
+  }
+
+  public static AdoptionDto of(Adoption adoption, Bookmark bookmark) {
+    return AdoptionDto.builder()
+        .bookmarkId(bookmark.getId())
         .adoptionId(adoption.getId())
         .userId(adoption.getUser().getId())
         .userNickname(adoption.getUser().getNickname())

--- a/src/main/java/homes/banzzokee/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/homes/banzzokee/domain/bookmark/controller/BookmarkController.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,8 +36,9 @@ public class BookmarkController {
   private final BookmarkService bookmarkService;
 
   @PostMapping
-  public ResponseEntity<Void> registerBookmark(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                               @Valid @RequestBody BookmarkRegisterRequest bookmarkRegisterRequest) {
+  public ResponseEntity<Void> registerBookmark(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody BookmarkRegisterRequest bookmarkRegisterRequest) {
     bookmarkService.registerBookmark(userDetails, bookmarkRegisterRequest);
     URI location = ServletUriComponentsBuilder.fromCurrentRequest()
         .path("/{adoptionId}")
@@ -45,8 +48,9 @@ public class BookmarkController {
   }
 
   @DeleteMapping("/{bookmarkId}")
-  public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                             @PathVariable long bookmarkId) {
+  public ResponseEntity<Void> deleteBookmark(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @PathVariable long bookmarkId) {
     bookmarkService.deleteBookmark(userDetails, bookmarkId);
     return ResponseEntity.ok().build();
   }
@@ -55,8 +59,10 @@ public class BookmarkController {
   public ResponseEntity<Slice<AdoptionDto>> findAllBookmark(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestParam(required = false, defaultValue = PAGE_DEFAULT_VALUE) int page,
-      @RequestParam(required = false, defaultValue = SIZE_DEFAULT_VALUE) int size) {
-    Pageable pageable = PageRequest.of(page, size);
+      @RequestParam(required = false, defaultValue = SIZE_DEFAULT_VALUE) int size,
+      @RequestParam(required = false, defaultValue = "desc") String direction) {
+    Pageable pageable = PageRequest.of(page, size,
+        Sort.by(Direction.fromString(direction), "createdAt"));
     return ResponseEntity.ok(bookmarkService.findAllBookmark(userDetails, pageable));
   }
 }

--- a/src/main/java/homes/banzzokee/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/homes/banzzokee/domain/bookmark/entity/Bookmark.java
@@ -1,6 +1,7 @@
 package homes.banzzokee.domain.bookmark.entity;
 
 import homes.banzzokee.domain.adoption.entity.Adoption;
+import homes.banzzokee.domain.common.entity.BaseEntity;
 import homes.banzzokee.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
-public class Bookmark {
+public class Bookmark extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/homes/banzzokee/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/homes/banzzokee/domain/bookmark/service/BookmarkService.java
@@ -79,7 +79,7 @@ public class BookmarkService {
       throw new BookmarkNotFoundException();
     }
     List<AdoptionDto> adoptionDtos = bookmarks.getContent().stream()
-        .map(bookmark -> AdoptionDto.fromEntity(bookmark.getAdoption()))
+        .map(bookmark -> AdoptionDto.of(bookmark.getAdoption(), bookmark))
         .collect(Collectors.toList());
     return new SliceImpl<>(adoptionDtos, bookmarks.getPageable(), bookmarks.hasNext());
   }

--- a/src/main/java/homes/banzzokee/domain/user/controller/UserController.java
+++ b/src/main/java/homes/banzzokee/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package homes.banzzokee.domain.user.controller;
 
 import homes.banzzokee.domain.user.dto.FollowDto;
+import homes.banzzokee.domain.user.dto.FollowDto.FollowUserDto;
 import homes.banzzokee.domain.user.dto.PasswordChangeRequest;
 import homes.banzzokee.domain.user.dto.PasswordChangeResponse;
 import homes.banzzokee.domain.user.dto.UserProfileDto;
@@ -13,6 +14,10 @@ import homes.banzzokee.global.security.UserDetailsImpl;
 import homes.banzzokee.global.validator.annotation.ImageFile;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -76,5 +82,16 @@ public class UserController {
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
     return userService.updateUserProfile(request, profileImg,
         userDetails.getUserId());
+  }
+
+  @GetMapping("/me/followers")
+  public Slice<FollowUserDto> getMyFollowers(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @RequestParam(required = false, defaultValue = "0") int page,
+      @RequestParam(required = false, defaultValue = "10") int size,
+      @RequestParam(required = false, defaultValue = "desc") String direction) {
+    PageRequest pageRequest = PageRequest.of(page, size,
+        Sort.by(Direction.fromString(direction), "createdAt"));
+    return userService.getMyFollowers(userDetails.getUserId(), pageRequest);
   }
 }

--- a/src/main/java/homes/banzzokee/domain/user/dao/FollowRepository.java
+++ b/src/main/java/homes/banzzokee/domain/user/dao/FollowRepository.java
@@ -1,7 +1,9 @@
 package homes.banzzokee.domain.user.dao;
 
 import homes.banzzokee.domain.user.entity.Follow;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
   Optional<Follow> findByFolloweeIdAndFollowerId(long followeeId, long followerId);
+  List<Follow> findAllByFollowerId(long followeeId, Pageable pageable);
 }

--- a/src/main/java/homes/banzzokee/domain/user/service/UserService.java
+++ b/src/main/java/homes/banzzokee/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import homes.banzzokee.domain.type.S3Object;
 import homes.banzzokee.domain.user.dao.FollowRepository;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.dto.FollowDto;
+import homes.banzzokee.domain.user.dto.FollowDto.FollowUserDto;
 import homes.banzzokee.domain.user.dto.PasswordChangeRequest;
 import homes.banzzokee.domain.user.dto.PasswordChangeResponse;
 import homes.banzzokee.domain.user.dto.UserProfileDto;
@@ -26,9 +27,13 @@ import homes.banzzokee.domain.user.exception.UserAlreadyWithdrawnException;
 import homes.banzzokee.domain.user.exception.UserNotFoundException;
 import homes.banzzokee.event.FcmTopicStatusChangeEvent;
 import homes.banzzokee.infra.fileupload.service.FileUploadService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -207,5 +212,13 @@ public class UserService {
       // TODO: 삭제 못한 이미지에 대한 예외 처리
       log.error("delete profile image failed. file={}", oldProfileImage, e);
     }
+  }
+
+  public Slice<FollowUserDto> getMyFollowers(long userId, Pageable pageable) {
+    List<Follow> myFollowers = followRepository.findAllByFollowerId(userId, pageable);
+    return new SliceImpl<>(myFollowers.stream().map(follow -> FollowUserDto.builder()
+        .userId(follow.getFollowee().getId())
+        .nickname(follow.getFollowee().getNickname())
+        .build()).toList());
   }
 }

--- a/src/test/java/homes/banzzokee/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/bookmark/controller/BookmarkControllerTest.java
@@ -32,6 +32,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -82,7 +84,8 @@ class BookmarkControllerTest {
     verify(bookmarkService).registerBookmark(
         any(UserDetailsImpl.class), any(BookmarkRegisterRequest.class));
     resultActions.andExpect(status().isCreated())
-        .andExpect(header().string("Location", containsString("/api/bookmarks/" + bookmarkId)));
+        .andExpect(
+            header().string("Location", containsString("/api/bookmarks/" + bookmarkId)));
   }
 
   @Test
@@ -93,7 +96,8 @@ class BookmarkControllerTest {
     long bookmarkId = 1L;
 
     // when & then
-    ResultActions resultActions = mockMvc.perform(delete("/api/bookmarks/{bookmarkId}", bookmarkId));
+    ResultActions resultActions = mockMvc.perform(
+        delete("/api/bookmarks/{bookmarkId}", bookmarkId));
 
     resultActions.andExpect(status().isOk());
     verify(bookmarkService).deleteBookmark(any(UserDetailsImpl.class), eq(bookmarkId));
@@ -104,7 +108,8 @@ class BookmarkControllerTest {
   @DisplayName("[북마크 전체 조회] - 성공 검증")
   void findAllBookmark_when_valid_then_success() throws Exception {
     // given
-    Pageable pageable = PageRequest.of(0, 10);
+    Pageable pageable = PageRequest.of(0, 10,
+        Sort.by(Direction.fromString("desc"), "createdAt"));
     AdoptionDto adoptionDto1 = AdoptionDto.builder()
         .userNickname("반쪽이").adoptionId(1L)
         .title("반쪽이입니다.").content("분양합니다.")
@@ -117,8 +122,10 @@ class BookmarkControllerTest {
         .build();
     List<AdoptionDto> adoptionDtoList = Collections.singletonList(adoptionDto1);
     Slice<AdoptionDto> adoptionsSlice = new SliceImpl<>(adoptionDtoList, pageable, true);
-    UserDetailsImpl userDetailsMock = (UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-    given(bookmarkService.findAllBookmark(any(UserDetailsImpl.class), eq(pageable))).willReturn(adoptionsSlice);
+    UserDetailsImpl userDetailsMock = (UserDetailsImpl) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
+    given(bookmarkService.findAllBookmark(any(UserDetailsImpl.class),
+        eq(pageable))).willReturn(adoptionsSlice);
 
     // when
     ResultActions resultActions = mockMvc.perform(get("/api/bookmarks/adoptions"));
@@ -131,18 +138,25 @@ class BookmarkControllerTest {
         .andExpect(jsonPath("$.content").isArray())
         .andExpect(jsonPath("$.content.length()").value(adoptionDtoList.size()))
         .andExpect(jsonPath("$.content[0].userId").value(adoptionDto1.getUserId()))
-        .andExpect(jsonPath("$.content[0].userNickname").value(adoptionDto1.getUserNickname()))
-        .andExpect(jsonPath("$.content[0].adoptionId").value(adoptionDto1.getAdoptionId()))
+        .andExpect(
+            jsonPath("$.content[0].userNickname").value(adoptionDto1.getUserNickname()))
+        .andExpect(
+            jsonPath("$.content[0].adoptionId").value(adoptionDto1.getAdoptionId()))
         .andExpect(jsonPath("$.content[0].title").value(adoptionDto1.getTitle()))
         .andExpect(jsonPath("$.content[0].content").value(adoptionDto1.getContent()))
-        .andExpect(jsonPath("$.content[0].breed.value").value(adoptionDto1.getBreed().getValue()))
-        .andExpect(jsonPath("$.content[0].size.value").value(adoptionDto1.getSize().getValue()))
+        .andExpect(jsonPath("$.content[0].breed.value").value(
+            adoptionDto1.getBreed().getValue()))
+        .andExpect(
+            jsonPath("$.content[0].size.value").value(adoptionDto1.getSize().getValue()))
         .andExpect(jsonPath("$.content[0].neutering").value(adoptionDto1.isNeutering()))
-        .andExpect(jsonPath("$.content[0].gender.value").value(adoptionDto1.getGender().getValue()))
+        .andExpect(jsonPath("$.content[0].gender.value").value(
+            adoptionDto1.getGender().getValue()))
         .andExpect(jsonPath("$.content[0].age").value(adoptionDto1.getAge()))
-        .andExpect(jsonPath("$.content[0].healthChecked").value(adoptionDto1.isHealthChecked()))
+        .andExpect(
+            jsonPath("$.content[0].healthChecked").value(adoptionDto1.isHealthChecked()))
         .andExpect(jsonPath("$.content[0].registeredAt").exists())
-        .andExpect(jsonPath("$.content[0].status.value").value(adoptionDto1.getStatus().getValue()))
+        .andExpect(jsonPath("$.content[0].status.value").value(
+            adoptionDto1.getStatus().getValue()))
         .andExpect(jsonPath("$.content[0].adoptedAt").exists())
         .andExpect(jsonPath("$.content[0].createdAt").exists())
         .andExpect(jsonPath("$.content[0].updatedAt").exists())

--- a/src/test/java/homes/banzzokee/domain/user/service/UserServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/user/service/UserServiceTest.java
@@ -540,10 +540,10 @@ class UserServiceTest {
         .nickname("user2")
         .build());
     followList.add(Follow.builder()
-        .follower(user1)
+        .followee(user1)
         .build());
     followList.add(Follow.builder()
-        .follower(user2)
+        .followee(user2)
         .build());
 
     given(followRepository.findAllByFollowerId(anyLong(), any(Pageable.class)))

--- a/src/test/java/homes/banzzokee/domain/user/service/UserServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/user/service/UserServiceTest.java
@@ -27,6 +27,7 @@ import homes.banzzokee.domain.type.S3Object;
 import homes.banzzokee.domain.user.dao.FollowRepository;
 import homes.banzzokee.domain.user.dao.UserRepository;
 import homes.banzzokee.domain.user.dto.FollowDto;
+import homes.banzzokee.domain.user.dto.FollowDto.FollowUserDto;
 import homes.banzzokee.domain.user.dto.PasswordChangeRequest;
 import homes.banzzokee.domain.user.dto.UserProfileDto;
 import homes.banzzokee.domain.user.dto.UserProfileUpdateRequest;
@@ -46,7 +47,9 @@ import homes.banzzokee.infra.fileupload.dto.FileDto;
 import homes.banzzokee.infra.fileupload.service.FileUploadService;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,6 +59,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -519,6 +527,42 @@ class UserServiceTest {
     // then
     verify(s3Service).deleteFile(file.getUrl());
   }
+
+  @Test
+  @DisplayName("[사용자 팔로워 목록 반환] - 성공검증")
+  void getMyFollowers_success() {
+    // given
+    List<Follow> followList = new ArrayList<>();
+    User user1 = spy(User.builder()
+        .nickname("user1")
+        .build());
+    User user2 = spy(User.builder()
+        .nickname("user2")
+        .build());
+    followList.add(Follow.builder()
+        .follower(user1)
+        .build());
+    followList.add(Follow.builder()
+        .follower(user2)
+        .build());
+
+    given(followRepository.findAllByFollowerId(anyLong(), any(Pageable.class)))
+        .willReturn(followList);
+    given(user1.getId()).willReturn(1L);
+    given(user2.getId()).willReturn(2L);
+
+    // when
+    PageRequest pageRequest = PageRequest.of(0, 10,
+        Sort.by(Direction.fromString("desc"), "createdAt"));
+    Slice<FollowUserDto> myFollowers = userService.getMyFollowers(1L, pageRequest);
+
+    // then
+    assertEquals(1L, myFollowers.getContent().get(0).getUserId());
+    assertEquals(2L, myFollowers.getContent().get(1).getUserId());
+    assertEquals("user1", myFollowers.getContent().get(0).getNickname());
+    assertEquals("user2", myFollowers.getContent().get(1).getNickname());
+  }
+
 
   private static Shelter createMockShelter() {
     Shelter shelter = spy(Shelter.builder()


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
- 내가 팔로우한 사용자 목록 조회 기능을 구현했습니다.
  - 로그인한 유저의 팔로워 목록을 반환합니다.(반환값 : userId, nickname)

- 북마크 목록 조회 기능을 리팩토링 진행했습니다.
  - bookmarkId 필드를 추가하였습니다.
  - 북마크 목록 정렬 기준을 등록일 순으로 반환할 수 있도록 추가하였습니다.
    - 등록일 기준으로 정렬하기 위해 기존 Bookmark 엔티티에 빠져있던 createAt, updatedAt 필드를 추가했습니다.

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
- 내가 팔로우한 팔로워 목록을 조회할 수 있습니다.
- 북마크 목록을 정렬된 순서로 조회하고, bookmarkId를 추가로 반환하여 북마크 삭제 기능에 사용합니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->
- bookmark 테이블에 created_at, updated_at 컬럼을 추가해야 합니다.
  - 제가 컬럼을 추가해보려 했으나 권한이 없어 진행하지 못 했습니다.

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
- 테스트 코드 작성 완료

## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
