### PR TITLE
refactor: 채팅방 생성, 조회 누락된 부분 코드 수정

### DIFF
--- a/src/main/java/homes/banzzokee/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/homes/banzzokee/domain/chat/service/ChatMessageService.java
@@ -50,7 +50,7 @@ public class ChatMessageService {
     User user = userRepository.findByEmailAndDeletedAtNull(email)
         .orElseThrow(SocketUserNotFoundException::new);
 
-    ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+    ChatRoom chatRoom = chatRoomRepository.findByIdAndDeletedAtIsNull(roomId)
         .orElseThrow(SocketRoomNotFoundException::new);
 
     if (!chatRoom.isParticipatedUser(user)) {
@@ -81,7 +81,7 @@ public class ChatMessageService {
   @Transactional(readOnly = true)
   public Slice<MessageDto> getChatList(Long roomId, Pageable pageable) {
 
-    ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+    ChatRoom chatRoom = chatRoomRepository.findByIdAndDeletedAtIsNull(roomId)
         .orElseThrow(() -> new SocketException(ROOM_NOT_FOUND));
 
     return chatMessageRepository.findAllByRoom(chatRoom, pageable)

--- a/src/main/java/homes/banzzokee/domain/room/dao/ChatRoomRepository.java
+++ b/src/main/java/homes/banzzokee/domain/room/dao/ChatRoomRepository.java
@@ -2,8 +2,10 @@ package homes.banzzokee.domain.room.dao;
 
 import homes.banzzokee.domain.adoption.entity.Adoption;
 import homes.banzzokee.domain.room.entity.ChatRoom;
+import homes.banzzokee.domain.shelter.entity.Shelter;
 import homes.banzzokee.domain.user.entity.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,8 +19,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   List<ChatRoom> findAllByShelterId(long shelterId);
 
-  Page<ChatRoom> findAllByUserOrderByLastMessageCreatedAtDesc(User user,
-      Pageable pageable);
+  Page<ChatRoom> findAllByUserOrShelterOrderByLastMessageCreatedAtDesc(User user,
+      Shelter shelter, Pageable pageable);
+
+  Optional<ChatRoom> findByIdAndDeletedAtIsNull(Long roomId);
 
   boolean existsByUserAndAdoption(User user, Adoption adoption);
 

--- a/src/main/java/homes/banzzokee/domain/room/dto/ChatRoomDto.java
+++ b/src/main/java/homes/banzzokee/domain/room/dto/ChatRoomDto.java
@@ -26,7 +26,12 @@ public class ChatRoomDto {
   private final ChatAdoptionDto adoption;
 
   /**
-   * 조회하는 유저
+   * 참여 보호소
+   */
+  private final ChatShelterDto shelter;
+
+  /**
+   * 본인
    */
   private final ChatUserDto user;
 
@@ -51,6 +56,7 @@ public class ChatRoomDto {
     return ChatRoomDto.builder()
         .roomId(chatRoom.getId())
         .adoption(ChatAdoptionDto.fromEntity(chatRoom.getAdoption()))
+        .shelter(ChatShelterDto.fromEntity(chatRoom.getShelter()))
         .user(ChatUserDto.fromEntity(chatRoom.getUser()))
         .lastMessage(chatRoom.getLastMessage())
         .lastMessageType(chatRoom.getLastMessageType())

--- a/src/main/java/homes/banzzokee/domain/room/dto/ChatShelterDto.java
+++ b/src/main/java/homes/banzzokee/domain/room/dto/ChatShelterDto.java
@@ -18,11 +18,15 @@ public class ChatShelterDto {
   private final String shelterImgUrl;
 
   private final String name;
+
+  private ChatUserDto user;
+
   public static ChatShelterDto fromEntity(Shelter shelter) {
     return ChatShelterDto.builder()
         .shelterId(shelter.getId())
         .shelterImgUrl(shelter.getShelterImageUrl())
         .name(shelter.getName())
+        .user(ChatUserDto.fromEntity(shelter.getUser()))
         .build();
   }
 

--- a/src/main/java/homes/banzzokee/domain/room/service/ChatRoomService.java
+++ b/src/main/java/homes/banzzokee/domain/room/service/ChatRoomService.java
@@ -14,6 +14,7 @@ import homes.banzzokee.domain.room.entity.ChatRoom;
 import homes.banzzokee.domain.room.exception.AdoptionWriterException;
 import homes.banzzokee.domain.room.exception.AlreadyExistsChatRoomException;
 import homes.banzzokee.domain.room.exception.RoomNotFoundException;
+import homes.banzzokee.domain.shelter.dao.ShelterRepository;
 import homes.banzzokee.domain.shelter.entity.Shelter;
 import homes.banzzokee.domain.type.MessageType;
 import homes.banzzokee.domain.user.dao.UserRepository;
@@ -39,6 +40,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
+  private final ShelterRepository shelterRepository;
   private final ChatMessageRepository chatMessageRepository;
   private final AdoptionRepository adoptionRepository;
   private final ChatRoomRepository chatRoomRepository;
@@ -93,8 +95,10 @@ public class ChatRoomService {
     User user = userRepository.findByEmailAndDeletedAtNull(email)
         .orElseThrow(UserNotFoundException::new);
 
+    Shelter shelter = shelterRepository.getByUser(user);
+
     Slice<ChatRoom> chatRooms = chatRoomRepository
-        .findAllByUserOrderByLastMessageCreatedAtDesc(user, pageable);
+        .findAllByUserOrShelterOrderByLastMessageCreatedAtDesc(user, shelter, pageable);
 
     return new SliceImpl<>(
         chatRooms.stream()

--- a/src/main/java/homes/banzzokee/domain/shelter/dao/ShelterRepository.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/dao/ShelterRepository.java
@@ -2,6 +2,8 @@ package homes.banzzokee.domain.shelter.dao;
 
 import homes.banzzokee.domain.shelter.dao.custom.CustomShelterRepository;
 import homes.banzzokee.domain.shelter.entity.Shelter;
+import homes.banzzokee.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface ShelterRepository extends JpaRepository<Shelter, Long>,
     CustomShelterRepository {
 
+  Optional<Shelter> findByIdAndDeletedAtIsNull(Long shelterId);
+
+  Shelter getByUser(User user);
 }

--- a/src/main/java/homes/banzzokee/domain/shelter/exception/ShelterNotFoundException.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/exception/ShelterNotFoundException.java
@@ -8,10 +8,7 @@ import lombok.Getter;
 @Getter
 public class ShelterNotFoundException extends CustomException {
 
-  private final Long shelterId;
-
-  public ShelterNotFoundException(Long shelterId) {
+  public ShelterNotFoundException() {
     super(SHELTER_NOT_FOUND);
-    this.shelterId = shelterId;
   }
 }

--- a/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
+++ b/src/main/java/homes/banzzokee/domain/shelter/service/ShelterService.java
@@ -46,7 +46,7 @@ public class ShelterService {
    */
   @Transactional
   public void registerShelter(ShelterRegisterRequest request, MultipartFile shelterImg,
-                              long userId) {
+      long userId) {
     User user = findByUserIdOrThrow(userId);
 
     throwIfUserAlreadyRegisterShelter(user);
@@ -84,7 +84,7 @@ public class ShelterService {
    */
   @Transactional
   public ShelterUpdateResponse updateShelter(long shelterId, ShelterUpdateRequest request,
-                                             MultipartFile shelterImage, long userId) {
+      MultipartFile shelterImage, long userId) {
     User user = findByUserIdOrThrow(userId);
     Shelter shelter = findByShelterIdOrThrow(shelterId);
 
@@ -196,14 +196,10 @@ public class ShelterService {
    * @return 보호소
    */
   private Shelter findByShelterIdOrThrow(long shelterId) {
-    Shelter shelter = shelterRepository.findById(shelterId)
-        .orElseThrow(() -> new ShelterNotFoundException(shelterId));
 
-    if (shelter.isDeleted()) {
-      throw new ShelterNotFoundException(shelterId);
-    }
+    return shelterRepository.findByIdAndDeletedAtIsNull(shelterId)
+        .orElseThrow(ShelterNotFoundException::new);
 
-    return shelter;
   }
 
   /**
@@ -214,7 +210,7 @@ public class ShelterService {
    * @param shelterImage 보호소 이미지
    */
   private void registerOrRestoreShelter(User user, ShelterRegisterRequest request,
-                                        S3Object shelterImage) {
+      S3Object shelterImage) {
     Shelter shelter = user.getShelter();
     String imageUrl = shelterImage == null ? null : shelterImage.getUrl();
 

--- a/src/main/java/homes/banzzokee/domain/type/MessageType.java
+++ b/src/main/java/homes/banzzokee/domain/type/MessageType.java
@@ -5,6 +5,5 @@ package homes.banzzokee.domain.type;
  */
 public enum MessageType {
   EXIT,
-  TEXT,
-  PHOTO
+  TEXT
 }

--- a/src/main/java/homes/banzzokee/global/config/stomp/StompWebSocketConfig.java
+++ b/src/main/java/homes/banzzokee/global/config/stomp/StompWebSocketConfig.java
@@ -35,9 +35,7 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws-stomp")
         // ws://localhost:8080/ws-stomp 로 연결
-        .setAllowedOriginPatterns("*")
-        .withSockJS(); // SockJs 사용 가능 설정
-    // http://localhost:8080/ws-stomp 로 연결 가능
+        .setAllowedOriginPatterns("*");
     registry.setErrorHandler(stompErrorHandler);
   }
 

--- a/src/test/java/homes/banzzokee/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/chat/service/ChatMessageServiceTest.java
@@ -68,7 +68,7 @@ class ChatMessageServiceTest {
         .user(user)
         .build();
 
-    given(chatRoomRepository.findById(eq(1L)))
+    given(chatRoomRepository.findByIdAndDeletedAtIsNull(eq(1L)))
         .willReturn(Optional.of(chatRoom));
 
     given(userRepository.findByEmailAndDeletedAtNull(eq("IncludedUser")))
@@ -133,7 +133,7 @@ class ChatMessageServiceTest {
             )
         );
 
-    given(chatRoomRepository.findById(eq(1L)))
+    given(chatRoomRepository.findByIdAndDeletedAtIsNull(eq(1L)))
         .willReturn(Optional.empty());
 
     //when
@@ -159,7 +159,7 @@ class ChatMessageServiceTest {
             )
         );
 
-    given(chatRoomRepository.findById(eq(1L)))
+    given(chatRoomRepository.findByIdAndDeletedAtIsNull(eq(1L)))
         .willReturn(Optional.of(
                 ChatRoom.builder()
                     .user(user)

--- a/src/test/java/homes/banzzokee/domain/room/service/ChatRoomServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/room/service/ChatRoomServiceTest.java
@@ -24,6 +24,7 @@ import homes.banzzokee.domain.room.dto.ChatUserDto;
 import homes.banzzokee.domain.room.entity.ChatRoom;
 import homes.banzzokee.domain.room.exception.AdoptionWriterException;
 import homes.banzzokee.domain.room.exception.AlreadyExistsChatRoomException;
+import homes.banzzokee.domain.shelter.dao.ShelterRepository;
 import homes.banzzokee.domain.shelter.entity.Shelter;
 import homes.banzzokee.domain.type.AdoptionStatus;
 import homes.banzzokee.domain.type.BreedType;
@@ -60,6 +61,9 @@ class ChatRoomServiceTest {
 
   @Mock
   private UserRepository userRepository;
+
+  @Mock
+  private ShelterRepository shelterRepository;
 
   @Mock
   private AdoptionRepository adoptionRepository;
@@ -122,6 +126,9 @@ class ChatRoomServiceTest {
         .loginType(LoginType.EMAIL)
         .shelter(null)
         .build();
+    Shelter shelter = Shelter.builder()
+        .user(User.builder().build())
+        .build();
 
     Adoption adoption1 = Adoption.builder()
         .title("테스트_입양글_제목_1")
@@ -145,18 +152,22 @@ class ChatRoomServiceTest {
 
     ChatRoom room1 = ChatRoom.builder()
         .user(GENERAL_USER)
+        .shelter(shelter)
         .adoption(adoption1)
         .build();
     ChatRoom room2 = ChatRoom.builder()
         .user(GENERAL_USER)
+        .shelter(shelter)
         .adoption(adoption2)
         .build();
     ChatRoom room3 = ChatRoom.builder()
         .user(GENERAL_USER)
+        .shelter(shelter)
         .adoption(adoption3)
         .build();
     ChatRoom room4 = ChatRoom.builder()
         .user(GENERAL_USER)
+        .shelter(shelter)
         .adoption(adoption4)
         .build();
 
@@ -167,9 +178,12 @@ class ChatRoomServiceTest {
 
     given(userRepository.findByEmailAndDeletedAtNull(anyString()))
         .willReturn(Optional.of(user));
-    given(chatRoomRepository.findAllByUserOrderByLastMessageCreatedAtDesc(any(User.class),
-        any(
-            Pageable.class)))
+    given(shelterRepository.getByUser(any(User.class)))
+        .willReturn(Shelter.builder()
+            .user(User.builder().build())
+            .build());
+    given(chatRoomRepository.findAllByUserOrShelterOrderByLastMessageCreatedAtDesc(
+        any(User.class), any(Shelter.class), any(Pageable.class)))
         .willReturn(new PageImpl<>(chatRoomList, pageRequest, chatRoomList.size()));
 
     //when
@@ -209,6 +223,7 @@ class ChatRoomServiceTest {
     given(adoption.getUser()).willReturn(otherUser);
     given(otherUser.getShelter()).willReturn(shelter);
     given(shelter.getId()).willReturn(1L);
+    given(shelter.getUser()).willReturn(otherUser);
 
     given(userRepository.findByEmailAndDeletedAtNull(eq(GENERAL_USER_EMAIL)))
         .willReturn(Optional.of(GENERAL_USER));

--- a/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/homes/banzzokee/domain/shelter/service/ShelterServiceTest.java
@@ -235,28 +235,11 @@ class ShelterServiceTest {
     User user = mock(User.class);
     given(user.getRole()).willReturn(getRoles(ROLE_ADMIN));
     given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-    given(shelterRepository.findById(1L)).willReturn(Optional.empty());
+    given(shelterRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
 
     // when & then
     assertThrows(ShelterNotFoundException.class,
         () -> shelterService.verifyShelter(1L, anyLong()));
-  }
-
-  @Test
-  @DisplayName("[보호소 승인] - 삭제된 보호소이면 ShelterNotFoundException 발생")
-  void verifyShelter_when_shelterIsDeleted_then_throwShelterNotFoundException() {
-    // given
-    User user = mock(User.class);
-    given(user.getRole()).willReturn(getRoles(ROLE_ADMIN));
-    given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-
-    Shelter shelter = mock(Shelter.class);
-    given(shelter.isDeleted()).willReturn(true);
-    given(shelterRepository.findById(1L)).willReturn(Optional.of(shelter));
-
-    // when & then
-    assertThrows(ShelterNotFoundException.class,
-        () -> shelterService.verifyShelter(1L, user.getId()));
   }
 
   @Test
@@ -269,7 +252,7 @@ class ShelterServiceTest {
 
     Shelter shelter = mock(Shelter.class);
     given(shelter.isVerified()).willReturn(true);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when & then
     assertThrows(ShelterAlreadyVerifiedException.class,
@@ -288,7 +271,7 @@ class ShelterServiceTest {
 
     Shelter shelter = spy(Shelter.builder().user(user).build());
     given(shelter.getId()).willReturn(1L);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
     shelterService.verifyShelter(shelter.getId(), user.getId());
@@ -307,7 +290,7 @@ class ShelterServiceTest {
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
     Shelter shelter = mock(Shelter.class);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.empty());
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.empty());
 
     // when & then
     assertThrows(ShelterNotFoundException.class,
@@ -323,7 +306,7 @@ class ShelterServiceTest {
     // given
     Shelter shelter = mock(Shelter.class);
     given(shelter.getUser()).willReturn(mock(User.class));
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     User user = mock(User.class);
     given(user.getId()).willReturn(1L);
@@ -349,7 +332,7 @@ class ShelterServiceTest {
     Shelter shelter = mock(Shelter.class);
     given(shelter.getUser()).willReturn(user);
     given(shelter.getShelterImage()).willReturn(oldShelterImage);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
     shelterService.updateShelter(shelter.getId(),
@@ -370,7 +353,7 @@ class ShelterServiceTest {
 
     Shelter shelter = mock(Shelter.class);
     given(shelter.getUser()).willReturn(user);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     // when
     shelterService.updateShelter(shelter.getId(),
@@ -394,7 +377,7 @@ class ShelterServiceTest {
         .build());
     given(shelter.getId()).willReturn(1L);
     given(shelter.getUser()).willReturn(user);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     given(s3Service.uploadOneFile(mockFile, FilePath.SHELTER)).willReturn(image);
 
@@ -420,7 +403,7 @@ class ShelterServiceTest {
     // given
     User user = mock(User.class);
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-    given(shelterRepository.findById(anyLong())).willReturn(Optional.empty());
+    given(shelterRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.empty());
 
     // when & then
     assertThrows(ShelterNotFoundException.class,
@@ -440,7 +423,7 @@ class ShelterServiceTest {
 
     Shelter shelter = mock(Shelter.class);
     given(shelter.getUser()).willReturn(user2);
-    given(shelterRepository.findById(anyLong())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.of(shelter));
 
     // when & then
     assertThrows(NoAuthorizedException.class,
@@ -455,7 +438,7 @@ class ShelterServiceTest {
         .user(User.builder().build())
         .build());
     given(shelter.getId()).willReturn(1L);
-    given(shelterRepository.findById(shelter.getId())).willReturn(Optional.of(shelter));
+    given(shelterRepository.findByIdAndDeletedAtIsNull(shelter.getId())).willReturn(Optional.of(shelter));
 
     User user = spy(User.builder()
         .role(getRoles(ROLE_USER, ROLE_SHELTER))


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
1. ChatRepository의 findById 수정
   - findByIdAndDeletedAtIsNull 로 변경
   - 삭제되지 않은 채팅방만 조회할 수 있도록 수정했습니다.

2. ChatRepository의 채팅방 조회 by User -> by UserOrShelter
   - Shelter입장에서 채팅방 조회는 안되고 있던 중이라 수정했습니다.

3. ShelterNotFoundException 수정
   - 채팅방에서 필요한 Shelter 조회에서는 ShelterId값을 넘겨줄 수 없어서 수정했습니다.

4. StompConfig 코드 수정
   - 토큰이 있을때 에러반환 안되던버그
   - if (token != null) 일때 catch 로 에러 받아서 처리할 수 있도록 수정

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
채팅 관련 로직에서 누락된 부분을 확인하고 수정할 필요가 있었습니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->

## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
