### PR TITLE
refactor: logout & reissueAccessToken API 수정

### DIFF
--- a/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
+++ b/src/main/java/homes/banzzokee/domain/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package homes.banzzokee.domain.auth.controller;
 
 import homes.banzzokee.domain.auth.dto.*;
 import homes.banzzokee.domain.auth.service.AuthService;
+import homes.banzzokee.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
   private final AuthService authService;
+  private final JwtTokenProvider jwtTokenProvider;
 
   @PostMapping("/sign-up")
   public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest signupRequest) {
@@ -45,14 +48,13 @@ public class AuthController {
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
-    authService.logout(token);
+  public ResponseEntity<Void> logout(HttpServletRequest request) {
+    authService.logout(request.getHeader("Authorization"));
     return ResponseEntity.ok().build();
   }
 
   @PostMapping("/token/reissue")
-  public ResponseEntity<TokenResponse> reissueAccessToken(@RequestHeader("Authorization")
-                                                            String refreshToken) {
-    return ResponseEntity.ok(authService.reissueAccessToken(refreshToken));
+  public ResponseEntity<TokenResponse> reissueAccessToken(HttpServletRequest request) {
+    return ResponseEntity.ok(authService.reissueAccessToken(request.getHeader("Authorization")));
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/exception/TokenRequiredException.java
+++ b/src/main/java/homes/banzzokee/global/security/exception/TokenRequiredException.java
@@ -1,0 +1,12 @@
+package homes.banzzokee.global.security.exception;
+
+import homes.banzzokee.global.error.exception.CustomException;
+
+import static homes.banzzokee.global.error.ErrorCode.TOKEN_REQUIRED;
+
+public class TokenRequiredException extends CustomException {
+
+  public TokenRequiredException() {
+    super(TOKEN_REQUIRED);
+  }
+}

--- a/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/homes/banzzokee/global/security/jwt/JwtAuthenticationFilter.java
@@ -51,11 +51,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       if (token != null) {
         getAuthenticate(token);
       } else {
-        request.setAttribute("exception", NO_AUTHORIZED);
         if (request.getRequestURI().contains("/MyPage") ||
             request.getRequestURI().contains("/favicon.ico")) {
           return;
         }
+        request.setAttribute("exception", NO_AUTHORIZED);
       }
     } catch (ExpiredJwtException e) {
       request.setAttribute("exception", ACCESS_TOKEN_EXPIRED);

--- a/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/homes/banzzokee/domain/auth/controller/AuthControllerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import homes.banzzokee.domain.auth.dto.*;
 import homes.banzzokee.domain.auth.service.AuthService;
 import homes.banzzokee.global.security.jwt.JwtAuthenticationFilter;
+import homes.banzzokee.global.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +45,9 @@ class AuthControllerTest {
 
   @MockBean
   private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
 
   @Test
   @DisplayName("[이메일 전송] - 성공 검증")


### PR DESCRIPTION
## Changes
- logout & reissueAccessToken API 를 수정하였습니다.
  - @RequestHeader("Authorization") 해당 어노테이션으로 요청받을 때 토큰 없이 요청하는 경우 검증이 불가하여 HttpServletRequest request 로 요청 받도록 수정하였습니다.
  - 토큰 없이 요청할 경우 검증할 수 있도록 추가하였습니다.
  - 로그아웃 서비스에 validateToken() 메소드 제거 및 잘못된 토큰으로 요청했을 때 검증 할 수 있도록 검증 로직 추가하였습니다.
## Background
## Discuss

## Issues

## Execute
- 테스트 코드 수정하였습니다.

## Reference
