### PR TITLE
refactor: oauth2 success handler

### DIFF
--- a/src/main/java/homes/banzzokee/global/security/config/SecurityConfig.java
+++ b/src/main/java/homes/banzzokee/global/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 
         .authorizeHttpRequests(authorizeRequests -> authorizeRequests
             .requestMatchers("/error").permitAll()
-            .requestMatchers("/oauth2/**").permitAll()
+            .requestMatchers("/api/oauth2/**").permitAll()
             .requestMatchers("/api/auth/**").permitAll()
             .requestMatchers("/api/users/**").hasAnyRole("USER")
             .requestMatchers("/api/shelters/{shelterId}/verify").hasAnyRole("ADMIN")

--- a/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 public class OAuth2Controller {
 
   private final Oauth2Service oauth2Service;
-  private final JwtTokenProvider jwtTokenProvider;
 
   @PostMapping("/sign-up")
   public ResponseEntity<TokenResponse> signup(@RequestHeader("Authorization") String token,

--- a/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
@@ -1,8 +1,11 @@
 package homes.banzzokee.global.security.oauth2.controller;
 
 import homes.banzzokee.domain.auth.dto.TokenResponse;
+import homes.banzzokee.global.security.jwt.JwtTokenProvider;
 import homes.banzzokee.global.security.oauth2.dto.NicknameRequest;
+import homes.banzzokee.global.security.oauth2.dto.OAuth2Response;
 import homes.banzzokee.global.security.oauth2.service.Oauth2Service;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +17,20 @@ import org.springframework.web.bind.annotation.*;
 public class OAuth2Controller {
 
   private final Oauth2Service oauth2Service;
+  private final JwtTokenProvider jwtTokenProvider;
 
   @PostMapping("/sign-up")
   public ResponseEntity<TokenResponse> signup(@RequestHeader("Authorization") String token,
                                               @Valid @RequestBody NicknameRequest nicknameRequest) {
     return ResponseEntity.ok(oauth2Service.signup(token,nicknameRequest));
+  }
+
+  @GetMapping("/success")
+  public OAuth2Response oAuth2LoginSuccess(HttpServletRequest request) {
+    return OAuth2Response.builder()
+        .accessToken(request.getSession().getAttribute("accessToken").toString())
+        .refreshToken(request.getSession().getAttribute("refreshToken").toString())
+        .firstLogin((Boolean) request.getSession().getAttribute("isFirstLogin"))
+        .build();
   }
 }

--- a/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/controller/OAuth2Controller.java
@@ -1,7 +1,6 @@
 package homes.banzzokee.global.security.oauth2.controller;
 
 import homes.banzzokee.domain.auth.dto.TokenResponse;
-import homes.banzzokee.global.security.jwt.JwtTokenProvider;
 import homes.banzzokee.global.security.oauth2.dto.NicknameRequest;
 import homes.banzzokee.global.security.oauth2.dto.OAuth2Response;
 import homes.banzzokee.global.security.oauth2.service.Oauth2Service;
@@ -9,7 +8,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/homes/banzzokee/global/security/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/dto/OAuth2Response.java
@@ -1,0 +1,14 @@
+package homes.banzzokee.global.security.oauth2.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuth2Response {
+
+  private final String accessToken;
+  private final String refreshToken;
+  private final boolean firstLogin;
+
+}

--- a/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/homes/banzzokee/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-  public static final String SUCCESS_URI = "/MyPage";
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
 
@@ -32,9 +31,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String refreshToken = jwtTokenProvider.createRefreshToken(oauth2User.getUsername());
     redisService.setRefreshToken(
         oauth2User.getUsername(), refreshToken, jwtTokenProvider.getRefreshTokenExpire());
-    String redirectUrl;
-    redirectUrl = SUCCESS_URI + "?accessToken=" + accessToken +
-        "&isFirstLogin=" + oauth2User.isFirstLogin();
-    getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+
+    request.getSession().setAttribute("accessToken", accessToken);
+    request.getSession().setAttribute("refreshToken", refreshToken);
+    request.getSession().setAttribute("isFirstLogin", oauth2User.isFirstLogin());
+    getRedirectStrategy().sendRedirect(request, response, "/api/oauth2/success");
   }
 }


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
- 기존 OAuth2SuccessHandler에서 리다이렉션하는 부분을 수정해봤습니다.
  - 기존 : 프론트엔드 분들이 만드신 MyPage로 queryString으로 token, 처음 로그인 여부를 담아서 리다이렉션
  - 변경 : 별도 api를 만들어(/api/oauth2/success) 세션에 token, 처음 로그인 여부를 담아 앞서 작성한 api로 리다이렉션 후 세션에서 정보를 조회하여 토큰정보 및 첫 로그인 여부 반환

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
- 프론트엔드 분들이 배포가 안 된다면 소셜로그인하는 것이 불안정 할 수도 있을 것 같아, 서버에서 자체 리다이렉션하여 안정성을 높입니다.
## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->


## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
![image](https://github.com/banzzokee/banzzokee-back/assets/141199772/2621928e-f704-4826-a9ca-79fa779264ba)
- 로컬에서 테스트 해봤을 때는 정상 동작합니다.
## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
