### PR TITLE
feature: sync rdb to elasticsearch

### DIFF
--- a/src/main/java/homes/banzzokee/consumer/elasticsearch/SyncAdoptionToElasticSearchConsumer.java
+++ b/src/main/java/homes/banzzokee/consumer/elasticsearch/SyncAdoptionToElasticSearchConsumer.java
@@ -1,0 +1,41 @@
+package homes.banzzokee.consumer.elasticsearch;
+
+import homes.banzzokee.consumer.error.exception.AdoptionNotFoundException;
+import homes.banzzokee.domain.adoption.dao.AdoptionRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.dao.AdoptionSearchRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.document.AdoptionDocument;
+import homes.banzzokee.domain.adoption.entity.Adoption;
+import homes.banzzokee.event.EntityEvent;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SyncAdoptionToElasticSearchConsumer {
+
+  private final AdoptionRepository adoptionRepository;
+  private final AdoptionSearchRepository adoptionSearchRepository;
+
+  @Transactional(readOnly = true)
+  @RabbitListener(queues = {
+      "queue.sync.elasticsearch.adoption",
+      "dlq.sync.elasticsearch.adoption"
+  }, errorHandler = "customErrorHandler")
+  public void handleEvent(@Payload EntityEvent event,
+      @Header(required = false, name = "x-death") Map<String, Object> xDeath,
+      Message mqMessage) {
+
+    Long adoptionId = event.getPayload().getId();
+
+    Adoption adoption = adoptionRepository.findById(adoptionId)
+        .orElseThrow(() -> new AdoptionNotFoundException(adoptionId));
+
+    adoptionSearchRepository.save(AdoptionDocument.fromEntity(adoption));
+  }
+}

--- a/src/main/java/homes/banzzokee/consumer/elasticsearch/SyncReviewToElasticSearchConsumer.java
+++ b/src/main/java/homes/banzzokee/consumer/elasticsearch/SyncReviewToElasticSearchConsumer.java
@@ -1,0 +1,41 @@
+package homes.banzzokee.consumer.elasticsearch;
+
+import homes.banzzokee.consumer.error.exception.ReviewNotFoundException;
+import homes.banzzokee.domain.adoption.elasticsearch.dao.AdoptionSearchRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.document.AdoptionDocument;
+import homes.banzzokee.domain.review.dao.ReviewRepository;
+import homes.banzzokee.domain.review.entity.Review;
+import homes.banzzokee.event.EntityEvent;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SyncReviewToElasticSearchConsumer {
+
+  private final AdoptionSearchRepository adoptionSearchRepository;
+  private final ReviewRepository reviewRepository;
+
+  @Transactional(readOnly = true)
+  @RabbitListener(queues = {
+      "queue.sync.elasticsearch.review",
+      "dlq.sync.elasticsearch.review"
+  }, errorHandler = "customErrorHandler")
+  public void handleEvent(@Payload EntityEvent event,
+      @Header(required = false, name = "x-death") Map<String, Object> xDeath,
+      Message mqMessage) {
+
+    Long reviewId = event.getPayload().getId();
+
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+
+    adoptionSearchRepository.save(AdoptionDocument.fromEntity(review.getAdoption()));
+  }
+}

--- a/src/main/java/homes/banzzokee/event/type/EntityAction.java
+++ b/src/main/java/homes/banzzokee/event/type/EntityAction.java
@@ -11,7 +11,9 @@ public enum EntityAction {
   ADOPTION_DELETED("adoption.deleted"),
   ADOPTION_STATUS_CHANGED("adoption.status.changed"),
 
-  REVIEW_CREATED("review.created");
+  REVIEW_CREATED("review.created"),
+  REVIEW_UPDATED("review.updated"),
+  REVIEW_DELETED("review.deleted");
 
   private final String routingKey;
 }

--- a/src/test/java/homes/banzzokee/consumer/elasticsearch/SyncAdoptionToElasticSearchConsumerTest.java
+++ b/src/test/java/homes/banzzokee/consumer/elasticsearch/SyncAdoptionToElasticSearchConsumerTest.java
@@ -1,0 +1,100 @@
+package homes.banzzokee.consumer.elasticsearch;
+
+import static homes.banzzokee.domain.type.AdoptionStatus.ADOPTING;
+import static homes.banzzokee.domain.type.BreedType.RETRIEVER;
+import static homes.banzzokee.domain.type.DogGender.FEMALE;
+import static homes.banzzokee.domain.type.DogSize.LARGE;
+import static homes.banzzokee.event.type.EntityAction.ADOPTION_CREATED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import homes.banzzokee.consumer.error.exception.AdoptionNotFoundException;
+import homes.banzzokee.domain.adoption.dao.AdoptionRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.dao.AdoptionSearchRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.document.AdoptionDocument;
+import homes.banzzokee.domain.adoption.entity.Adoption;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.event.EntityEvent;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SyncAdoptionToElasticSearchConsumerTest {
+
+  @InjectMocks
+  private SyncAdoptionToElasticSearchConsumer consumer;
+
+  @Mock
+  private AdoptionSearchRepository adoptionSearchRepository;
+
+  @Mock
+  private AdoptionRepository adoptionRepository;
+
+  @Test
+  @DisplayName("[분양 게시글 이벤트 처리] - 분양 게시글이 존재하지 않으면 AdoptionNotFoundException 발생")
+  void handleEvent_when_adoptionNotExists_then_throwAdoptionNotFoundException() {
+    // given
+    given(adoptionRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(AdoptionNotFoundException.class,
+        () -> consumer.handleEvent(EntityEvent.of(1L, ADOPTION_CREATED), null, null));
+  }
+
+  @Test
+  @DisplayName("[분양 게시글 이벤트 처리] - 성공 검증")
+  void handleEvent_when_success_then_verify() {
+    // given
+    User user = mock(User.class);
+    given(user.getId()).willReturn(1L);
+    given(user.getNickname()).willReturn("nickname");
+
+    Adoption adoption = spy(Adoption.builder()
+        .user(user)
+        .title("title")
+        .content("content")
+        .breed(RETRIEVER)
+        .size(LARGE)
+        .neutering(true)
+        .gender(FEMALE)
+        .age(1)
+        .healthChecked(true)
+        .status(ADOPTING)
+        .build());
+
+    given(adoptionRepository.findById(anyLong())).willReturn(Optional.of(adoption));
+
+    // when
+    consumer.handleEvent(EntityEvent.of(1L, ADOPTION_CREATED), null, null);
+
+    // then
+    ArgumentCaptor<AdoptionDocument> adoptionDocumentCaptor =
+        ArgumentCaptor.forClass(AdoptionDocument.class);
+    verify(adoptionSearchRepository).save(adoptionDocumentCaptor.capture());
+
+    AdoptionDocument adoptionDocument = adoptionDocumentCaptor.getValue();
+    assertEquals(1L, adoptionDocument.getUserId());
+    assertEquals("nickname", adoptionDocument.getUserNickname());
+    assertEquals("title", adoptionDocument.getTitle());
+    assertEquals("content", adoptionDocument.getContent());
+    assertEquals(RETRIEVER, adoptionDocument.getBreed());
+    assertEquals(LARGE, adoptionDocument.getSize());
+    assertTrue(adoptionDocument.isNeutering());
+    assertEquals(FEMALE, adoptionDocument.getGender());
+    assertEquals(1, adoptionDocument.getAge());
+    assertTrue(adoptionDocument.isHealthChecked());
+    assertEquals(ADOPTING, adoptionDocument.getStatus());
+  }
+}

--- a/src/test/java/homes/banzzokee/consumer/elasticsearch/SyncReviewToElasticSearchConsumerTest.java
+++ b/src/test/java/homes/banzzokee/consumer/elasticsearch/SyncReviewToElasticSearchConsumerTest.java
@@ -1,0 +1,104 @@
+package homes.banzzokee.consumer.elasticsearch;
+
+import static homes.banzzokee.domain.type.AdoptionStatus.ADOPTING;
+import static homes.banzzokee.domain.type.BreedType.RETRIEVER;
+import static homes.banzzokee.domain.type.DogGender.FEMALE;
+import static homes.banzzokee.domain.type.DogSize.LARGE;
+import static homes.banzzokee.event.type.EntityAction.ADOPTION_CREATED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import homes.banzzokee.consumer.error.exception.ReviewNotFoundException;
+import homes.banzzokee.domain.adoption.elasticsearch.dao.AdoptionSearchRepository;
+import homes.banzzokee.domain.adoption.elasticsearch.document.AdoptionDocument;
+import homes.banzzokee.domain.adoption.entity.Adoption;
+import homes.banzzokee.domain.review.dao.ReviewRepository;
+import homes.banzzokee.domain.review.entity.Review;
+import homes.banzzokee.domain.user.entity.User;
+import homes.banzzokee.event.EntityEvent;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SyncReviewToElasticSearchConsumerTest {
+
+  @InjectMocks
+  private SyncReviewToElasticSearchConsumer consumer;
+
+  @Mock
+  private AdoptionSearchRepository adoptionSearchRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Test
+  @DisplayName("[후기 게시글 이벤트 처리] - 후기 게시글이 존재하지 않으면 ReviewNotFoundException 발생")
+  void handleEvent_when_reviewNotExists_then_throwReviewNotFoundException() {
+    // given
+    given(reviewRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(ReviewNotFoundException.class,
+        () -> consumer.handleEvent(EntityEvent.of(1L, ADOPTION_CREATED), null, null));
+  }
+
+  @Test
+  @DisplayName("[후기 게시글 이벤트 처리] - 성공 검증")
+  void handleEvent_when_success_then_verify() {
+    // given
+    User user = mock(User.class);
+    given(user.getId()).willReturn(1L);
+    given(user.getNickname()).willReturn("nickname");
+
+    Adoption adoption = spy(Adoption.builder()
+        .user(user)
+        .title("title")
+        .content("content")
+        .breed(RETRIEVER)
+        .size(LARGE)
+        .neutering(true)
+        .gender(FEMALE)
+        .age(1)
+        .healthChecked(true)
+        .status(ADOPTING)
+        .build());
+
+    Review review = mock(Review.class);
+    given(review.getAdoption()).willReturn(adoption);
+
+    given(reviewRepository.findById(anyLong())).willReturn(Optional.of(review));
+
+    // when
+    consumer.handleEvent(EntityEvent.of(1L, ADOPTION_CREATED), null, null);
+
+    // then
+    ArgumentCaptor<AdoptionDocument> adoptionDocumentCaptor =
+        ArgumentCaptor.forClass(AdoptionDocument.class);
+    verify(adoptionSearchRepository).save(adoptionDocumentCaptor.capture());
+
+    AdoptionDocument adoptionDocument = adoptionDocumentCaptor.getValue();
+    assertEquals(1L, adoptionDocument.getUserId());
+    assertEquals("nickname", adoptionDocument.getUserNickname());
+    assertEquals("title", adoptionDocument.getTitle());
+    assertEquals("content", adoptionDocument.getContent());
+    assertEquals(RETRIEVER, adoptionDocument.getBreed());
+    assertEquals(LARGE, adoptionDocument.getSize());
+    assertTrue(adoptionDocument.isNeutering());
+    assertEquals(FEMALE, adoptionDocument.getGender());
+    assertEquals(1, adoptionDocument.getAge());
+    assertTrue(adoptionDocument.isHealthChecked());
+    assertEquals(ADOPTING, adoptionDocument.getStatus());
+  }
+}


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
- 분양 게시글, 후기 게시글의 생성, 수정 삭제 시 Service 클래스에서 RDB, ES 함께 저장하는 로직을 이벤트 리스터를 통해 처리하는 것으로 수정했습니다.

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
- 서비스 레이어에서 RDB, ES 동시에 저장하는 코드가 어색한 부분이 있었습니다.
- RDB는 정상이나, ES에 문제가 생기는 경우 롤백이 되기 때문에 장애가 발생할 수 있습니다.
- ES가 느려질 경우 클라이언트에도 응답이 느려질 수 있습니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->

## Issues
<!-- 관련된 이슈를 #{issueNumber}를 통해 태그해주세요. -->
<!-- ex) 해결한 이슈: #1, #2 -->
<!-- ex) 구현이 필요한 이슈: #3, #4 -->

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
- 기존 서비스 테스트 코드에서 ES 관련 테스트 부분을 모두 제거했습니다.
- 컨슈머 테스트에서 간결하게 작성했습니다.
  - RDB에 데이터가 없는 경우 예외를 발생
  - 성공 시 값 검증


## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->
